### PR TITLE
DEC-550: Plugin provides access to functions through variables, so type casting rules change slightly.

### DIFF
--- a/hop/context/load.go
+++ b/hop/context/load.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"plugin"
+	"reflect"
 	"sync"
 )
 
@@ -49,5 +50,10 @@ func connect[T any](p *plugin.Plugin, name string, target *T) {
 	if err != nil {
 		panic(err)
 	}
-	*target = sym.(T)
+
+	// Names in the plugin are associated with pointers to functions.
+	// Thus we cannot: *target = sym(T)
+	*target = reflect.ValueOf(sym). // *func(...) as reflect.Value
+					Elem().         // dereferences to func(...)
+					Interface().(T) // any.(func(...))
 }


### PR DESCRIPTION
This is a companion PR to nextmv-io/plugins#1. Exporting functions assigned to variables in a plugin implicitly casts them to pointers (`func(...)` becomes `*func(...)`). This changes the loading code slightly, since we can't cast to `sym.(*T)` with a generic type `T`. (Or, at least, I couldn't figure out how to.)