### PR TITLE
Fix naming oversight.

### DIFF
--- a/store/connect.go
+++ b/store/connect.go
@@ -43,8 +43,8 @@ func connect() {
 	plugin.Connect(slug, "StoreScope", &scopeFunc)
 
 	// Collections
-	plugin.Connect(slug, "StoreMapInt", &mapIntFunc)
-	plugin.Connect(slug, "StoreMapString", &mapStringFunc)
+	plugin.Connect(slug, "StoreNewMapInt", &newMapIntFunc)
+	plugin.Connect(slug, "StoreNewMapString", &newMapStringFunc)
 	plugin.Connect(slug, "StoreNewSlice", &newSliceFunc)
 
 	// Solver

--- a/store/map.go
+++ b/store/map.go
@@ -84,9 +84,9 @@ func NewMap[K Key, V any](s Store) Map[K, V] {
 
 	var k K
 	if isInt(k) {
-		p.mapInt = mapIntFunc(s)
+		p.mapInt = newMapIntFunc(s)
 	} else {
-		p.mapString = mapStringFunc(s)
+		p.mapString = newMapStringFunc(s)
 	}
 
 	return p
@@ -159,6 +159,6 @@ func isInt[K Key](k K) bool {
 }
 
 var (
-	mapIntFunc    func(Store) Map[int, any]
-	mapStringFunc func(Store) Map[string, any]
+	newMapIntFunc    func(Store) Map[int, any]
+	newMapStringFunc func(Store) Map[string, any]
 )


### PR DESCRIPTION
This corrects a naming oversight. `[Mm]apInt` and `[Mm]apString` should be `[Nn]ewMapInt` and `[Nn]ewMapString`. This is consistent with `[Nn]ewSlice`. This PR has a companion PR nextmv-io/plugins#33.