### PR TITLE
[ENG-1078] Returns zero value of undeclared variables.

### DIFF
--- a/store/variable.go
+++ b/store/variable.go
@@ -46,7 +46,13 @@ type variable[T any] struct {
 // Implements Variable.
 
 func (v variable[T]) Get(s Store) T {
-	return v.variable.Get(s).(T)
+	if value := v.variable.Get(s); value != nil {
+		return value.(T)
+	}
+
+	// zero-value of variable
+	var value T
+	return value
 }
 
 func (v variable[T]) Set(data T) Change {


### PR DESCRIPTION
This returns the `Variable.Get` logic to what it was before the `sdk` and `plugins` repositories were broken out. If a variable is unknown to a store, it returns its type's zero value. This fixes the bug for now, and we can discuss whether that is the correct behavior in a followup issue.