### PR TITLE
[ENG-1074]: Support interaction with Store from Router

### DIFF
--- a/route/router.go
+++ b/route/router.go
@@ -41,23 +41,24 @@ type Router interface {
 
 // Plan describes a solution to a Vehicle Routing Problem.
 type Plan struct {
-	Unassigned []Stop    `json:"unassigned"`
-	Vehicles   []Vehicle `json:"vehicles"`
+	Unassigned []Stop           `json:"unassigned"`
+	Vehicles   []PlannedVehicle `json:"vehicles"`
 }
 
-// Vehicle information of a solution to a Vehicle Routing Problem.
-type Vehicle struct {
+// PlannedVehicle holds information about the vehicle in a solution to a Vehicle
+// Routing Problem.
+type PlannedVehicle struct {
 	ID            string        `json:"id"`
-	Route         []VehicleStop `json:"route"`
+	Route         []PlannedStop `json:"route"`
 	RouteDuration int           `json:"route_duration"`
 }
 
-// VehicleStop describes a stop as part of a Vehicle's route of solution
+// PlannedStop describes a stop as part of a Vehicle's route of solution
 // to a Vehicle Routing Problem.
-type VehicleStop struct {
+type PlannedStop struct {
 	Stop
-	ETA *time.Time `json:"eta,omitempty"`
-	ETD *time.Time `json:"etd,omitempty"`
+	EstimatedArrival   *time.Time `json:"estimated_arrival,omitempty"`
+	EstimatedDeparture *time.Time `json:"estimated_departure,omitempty"`
 }
 
 // Stop to service in a Vehicle Routing Problem.

--- a/route/router.go
+++ b/route/router.go
@@ -10,9 +10,35 @@ import (
 type Router interface {
 	// Options configures the router with the given options. An error is
 	// returned if validation issues exist.
-	Options(opts ...Option) error
+	Options(...Option) error
 	// Solver receives solve options and returns a Solver interface.
-	Solver(opt store.Options) (store.Solver, error)
+	Solver(store.Options) (store.Solver, error)
+	// Plan returns a variable which holds information
+	// about the current set of unassigned stops and vehicles.
+	// The plan variable can be used to retrieve the values from the
+	// store of a solution.
+	Plan() store.Variable[Plan]
+}
+
+// Plan describes a solution to a Vehicle Routing Problem.
+type Plan struct {
+	Unassigned []Stop    `json:"unassigned"`
+	Vehicles   []Vehicle `json:"vehicles"`
+}
+
+// Vehicle information of a solution to a Vehicle Routing Problem.
+type Vehicle struct {
+	ID            string        `json:"id"`
+	Route         []VehicleStop `json:"route"`
+	RouteDuration int           `json:"route_duration"`
+}
+
+// VehicleStop describes a stop as part of a Vehicle's route of solution
+// to a Vehicle Routing Problem.
+type VehicleStop struct {
+	Stop
+	ETA *time.Time `json:"eta,omitempty"`
+	ETD *time.Time `json:"etd,omitempty"`
 }
 
 // Stop to service in a Vehicle Routing Problem.

--- a/route/router.go
+++ b/route/router.go
@@ -13,10 +13,29 @@ type Router interface {
 	Options(...Option) error
 	// Solver receives solve options and returns a Solver interface.
 	Solver(store.Options) (store.Solver, error)
-	// Plan returns a variable which holds information
-	// about the current set of unassigned stops and vehicles.
-	// The plan variable can be used to retrieve the values from the
-	// store of a solution.
+	/*
+		Plan returns a variable which holds information about the current set of
+		vehicles with their respective routes and any unassigned stops. The Plan
+		variable can be used to retrieve the values from the Store of a
+		Solution.
+
+			router, err := route.NewRouter(
+				stops,
+				vehicles,
+				route.Capacity(quantities, capacities),
+			)
+			if err != nil {
+				panic(err)
+			}
+			solver, err := router.Solver(store.DefaultOptions())
+			if err != nil {
+				panic(err)
+			}
+			solution := solver.Last(context.Background())
+			s := solution.Store
+			p := router.Plan()
+			vehicles, unassigned := p.Get(s).Vehicles, p.Get(s).Unassigned
+	*/
 	Plan() store.Variable[Plan]
 }
 


### PR DESCRIPTION
This adds a `Plan()` function to the `Router` interface which allows to retrieve a `store.Variable` of type `Plan`. A user can use that variable to query the `Store` for a solution. A user can do whatever they like with it, including all the usual store operations.

Naming still TBD. Happy for better ideas.

Example:
```go
router, _ := route.NewRouter(
	i.Stops,
	i.Vehicles,
	route.Capacity(i.Quantities, i.Capacities),
)
solver, _ := router.Solver(store.DefaultOptions())
solution := solver.Last(context.Background())
s := solution.Store
plan := router.Plan()
s = s.Format(func(s store.Store) any {
	return map[string]int{
		"num_unassigned": len(plan.Get(s).Unassigned),
		"num_vehicles":   len(plan.Get(s).Vehicles),
	}
})
```