### PR TITLE
Support the SDK module being replaced

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -37,10 +37,6 @@ jobs:
       - name: use ssh instead of https for git
         run: git config --global url."git@github.com:".insteadOf "https://github.com/"
 
-      - name: export sdk version
-        run: echo "VERSION=$(go run cmd/version/main.go)" >> $GITHUB_ENV
-        working-directory: ${{env.RESOURCES}}
-
       - name: export sdk path used in this action
         run: echo "SDK_PATH=$(pwd)" >> $GITHUB_ENV
 
@@ -53,10 +49,11 @@ jobs:
 
           # Create the path where the shared object binaries are going to be
           # saved.
+          VERSION=$(go run cmd/version/main.go)
           GOVERSION=$(go env GOVERSION)
           GOOS=$(go env GOOS)
           GOARCH=$(go env GOARCH)
-          OUT_PATH=${{env.NEXTMV_LIBRARY_PATH}}/nextmv-sdk-${{env.VERSION}}-$GOVERSION-$GOOS-$GOARCH.so
+          OUT_PATH=${{env.NEXTMV_LIBRARY_PATH}}/nextmv-sdk-$VERSION-$GOVERSION-$GOOS-$GOARCH.so
 
           # Build without -trimpath because the sdk dependency is being
           # replaced for the local sdk repo used in the action.

--- a/version.go
+++ b/version.go
@@ -18,11 +18,24 @@ var versionFallback string
 var VERSION = getVersion()
 
 func getVersion() string {
-	bi, _ := debug.ReadBuildInfo()
-	for _, dep := range bi.Deps {
-		if strings.HasPrefix(dep.Path, "github.com/nextmv-io/sdk") {
-			return dep.Version
-		}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return versionFallback
 	}
+
+	for _, dep := range bi.Deps {
+		// Get only care about this repo being used as a dependency.
+		if !strings.HasPrefix(dep.Path, "github.com/nextmv-io/sdk") {
+			continue
+		}
+
+		// If reference to this module was replaced, use fallback.
+		if dep.Replace != nil {
+			return versionFallback
+		}
+
+		return dep.Version
+	}
+
 	return versionFallback
 }

--- a/version.go
+++ b/version.go
@@ -24,7 +24,7 @@ func getVersion() string {
 	}
 
 	for _, dep := range bi.Deps {
-		// Get only care about this repo being used as a dependency.
+		// We only care about this repo being used as a dependency.
 		if !strings.HasPrefix(dep.Path, "github.com/nextmv-io/sdk") {
 			continue
 		}


### PR DESCRIPTION
# Description

When building the `.so` binaries and replacing `github.com/nextmv-io/sdk` for the local module the version was still being taken as a specific commit. However, to run the tests for `sdk`, the `dep.Version` is being taken as the fallback version. This is evident in [this action](https://github.com/nextmv-io/sdk/runs/7782265834?check_suite_focus=true).