### PR TITLE
[ENG-1442] Rename store.Variable to store.Var

### DIFF
--- a/route/example_router_test.go
+++ b/route/example_router_test.go
@@ -298,7 +298,7 @@ func ExampleRouter_options() {
 	// }
 }
 
-// Use the Plan func to get direct access to the underlying Store and Variables.
+// Use the Plan func to get direct access to the underlying Store and variables.
 func ExampleRouter_plan() {
 	// Define stops and vehicles.
 	stops := []route.Stop{

--- a/route/router.go
+++ b/route/router.go
@@ -39,7 +39,7 @@ type Router interface {
 			p := router.Plan()
 			vehicles, unassigned := p.Get(s).Vehicles, p.Get(s).Unassigned
 	*/
-	Plan() store.Variable[Plan]
+	Plan() store.Var[Plan]
 
 	// Format configures a custom output format for a solution.
 	Format(func(*Plan) any)

--- a/store/doc.go
+++ b/store/doc.go
@@ -1,11 +1,11 @@
 /*
 Package store provides a modeling kit for decision automation problems. It is
 based on the paradigm of "decisions as code". The base interface is the Store:
-a space defined by Variables and logic. Hop is an engine provided to search
+a space defined by variables and logic. Hop is an engine provided to search
 that space and find the best solution possible, this is, the best collection of
-Variable assignments. The Store is the root node of a search tree. Child Stores
-(nodes) inherit both logic and Variables from the parent and may also add new
-Variables and logic, or overwrite existing ones. Changes to a child do not
+variable assignments. The Store is the root node of a search tree. Child Stores
+(nodes) inherit both logic and variables from the parent and may also add new
+variables and logic, or overwrite existing ones. Changes to a child do not
 impact its parent.
 
 A new Store is defined.
@@ -18,7 +18,7 @@ Variables are stored in the Store.
 	y := store.NewSlice(s, 2, 3, 4)
 	z := store.NewMap[string, int](s)
 
-The Format of the Store can be set and one can get the value of a Variable.
+The Format of the Store can be set and one can get the value of a variable.
 
 	s = s.Format(
 		func(s store.Store) any {
@@ -30,7 +30,7 @@ The Format of the Store can be set and one can get the value of a Variable.
 		},
 	)
 
-The Value of the Store can be set. When maximizing or minimizing, Variable
+The Value of the Store can be set. When maximizing or minimizing, variable
 assignments are chosen so that this value increases or decreases, respectively.
 
 	s = s.Value(
@@ -43,7 +43,7 @@ assignments are chosen so that this value increases or decreases, respectively.
 		},
 	)
 
-Changes, like setting a new value on a Variable, can be applied to the Store.
+Changes, like setting a new value on a variable, can be applied to the Store.
 
 	s = s.Apply(
 		x.Set(10),
@@ -84,7 +84,7 @@ Value is not needed. Options are required to specify the search mechanics.
 	// solver := s.Value(...).Minimizer(opt)
 	// solver := s.Satisfier(opt)
 
-To find the best collection of Variable assignments in the Store, the last
+To find the best collection of variable assignments in the Store, the last
 Solution can be obtained from the given Solver. Alternatively, all Solutions
 can be retrieved to debug the search mechanics of the Solver.
 

--- a/store/domain.go
+++ b/store/domain.go
@@ -189,7 +189,7 @@ func Multiple(s Store, values ...int) Domain {
 }
 
 type domainProxy struct {
-	domain Variable[model.Domain]
+	domain Var[model.Domain]
 }
 
 // Implements store.Domain.

--- a/store/domains.go
+++ b/store/domains.go
@@ -270,7 +270,7 @@ func Repeat(s Store, n int, domain model.Domain) Domains {
 }
 
 type domainsProxy struct {
-	domains Variable[model.Domains]
+	domains Var[model.Domains]
 }
 
 // Implements store.Domains.

--- a/store/example_variable_test.go
+++ b/store/example_variable_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nextmv-io/sdk/store"
 )
 
-func ExampleVariable_get() {
+func ExampleVar_get() {
 	s := store.New()
 	x := store.NewVar(s, 10)
 	fmt.Println(x.Get(s))
@@ -15,7 +15,7 @@ func ExampleVariable_get() {
 	// 10
 }
 
-func ExampleVariable_set() {
+func ExampleVar_set() {
 	s := store.New()
 	x := store.NewVar(s, 10)
 	fmt.Println(x.Get(s))

--- a/store/map.go
+++ b/store/map.go
@@ -125,7 +125,7 @@ func (m mapProxy[K, V]) Get(s Store, key K) (V, bool) {
 	}
 
 ret:
-	// zero-value of variable
+	// zero-value of V
 	var value V
 	return value, false
 }

--- a/store/store.go
+++ b/store/store.go
@@ -21,7 +21,7 @@ const (
 )
 
 /*
-Store represents a store of Variables and logic to solve decision automation
+Store represents a store of variables and logic to solve decision automation
 problems. Adding logic to the Store updates it (functions may be called
 directly and chained):
 
@@ -31,12 +31,12 @@ directly and chained):
 	s = s.Format(...)   // 	   Format(...).
 	s = s.Generate(...) // 	   Generate(...)
 
-The Variables and logic stored define a solution space. This space is searched
+The variables and logic stored define a solution space. This space is searched
 to make decisions.
 */
 type Store interface {
 	/*
-		Apply changes to a Store. A change happens when a stored Variable is
+		Apply changes to a Store. A change happens when a stored variable is
 		updated:
 
 			s := store.New()
@@ -294,7 +294,7 @@ func (l Limits) MarshalJSON() ([]byte, error) {
 }
 
 // A Solver searches a space and finds the best Solution possible, this is, the
-// best collection of Variable assignments in an operationally valid Store.
+// best collection of variable assignments in an operationally valid Store.
 type Solver interface {
 	// All Solutions found by the Solver. Loop over the channel values to get
 	// the solutions.

--- a/store/variable.go
+++ b/store/variable.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 )
 
-// Variable stored in a Store.
-type Variable[T any] interface {
+// Var is a variable stored in a Store.
+type Var[T any] interface {
 	/*
-		Get the current value of the Variable in the Store.
+		Get the current value of the variable in the Store.
 
 			s := store.New()
 			x := store.NewVar(s, 10)
@@ -20,7 +20,7 @@ type Variable[T any] interface {
 	Get(Store) T
 
 	/*
-		Set a new value on the Variable.
+		Set a new value on the variable.
 
 			s := store.New()
 			x := store.NewVar(s, 10)
@@ -30,27 +30,27 @@ type Variable[T any] interface {
 }
 
 /*
-NewVar stores a new Variable in a Store.
+NewVar stores a new variable in a Store.
 
 	s := store.New()
 	x := store.NewVar(s, 10) // x is stored in s.
 */
-func NewVar[T any](s Store, data T) Variable[T] {
+func NewVar[T any](s Store, data T) Var[T] {
 	return variable[T]{variable: newVarFunc(s, data)}
 }
 
 type variable[T any] struct {
-	variable Variable[any]
+	variable Var[any]
 }
 
-// Implements Variable.
+// Implements Var.
 
 func (v variable[T]) Get(s Store) T {
 	if value := v.variable.Get(s); value != nil {
 		return value.(T)
 	}
 
-	// zero-value of variable
+	// zero-value of T
 	var value T
 	return value
 }
@@ -72,4 +72,4 @@ func (v variable[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.String())
 }
 
-var newVarFunc func(Store, any) Variable[any]
+var newVarFunc func(Store, any) Var[any]


### PR DESCRIPTION
# Description

This renames the interface `store.Variable` to `store.Var` to be closer to our coding conventions.