### PR TITLE
Feature/ENG-1448 domains remove allows for using it incorrectly

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -35,7 +35,7 @@ type Domain interface {
 	// Min of a domain and a boolean indicating it is nonempty.
 	Min() (int, bool)
 	// Remove values from a domain.
-	Remove(...int) Domain
+	Remove([]int) Domain
 	// Slice representation of a domain.
 	Slice() []int
 	// Value returns an int and true if a domain is singleton.
@@ -61,7 +61,7 @@ type Domains interface {
 	// Len returns the number of domains.
 	Len() int
 	// Remove values from a domain by index.
-	Remove(int, ...int) Domains
+	Remove(int, []int) Domains
 	// Singleton is true if all domains are Singleton.
 	Singleton() bool
 	// Slices convert domains to a slice of int slices.

--- a/store/domain.go
+++ b/store/domain.go
@@ -121,7 +121,7 @@ type Domain interface {
 
 			s1 := store.New()
 			d := store.NewDomain(s1, model.NewRange(1, 5))
-			s2 := s1.Apply(d.Remove(2, 4))
+			s2 := s1.Apply(d.Remove([]int{2, 4}))
 
 			d.Domain(s1) // [1, 5]
 			d.Domain(s2) // {1, 3, 5}

--- a/store/domain.go
+++ b/store/domain.go
@@ -126,7 +126,7 @@ type Domain interface {
 			d.Domain(s1) // [1, 5]
 			d.Domain(s2) // {1, 3, 5}
 	*/
-	Remove(...int) Change
+	Remove([]int) Change
 
 	/*
 		Slice representation of a Domain.
@@ -240,9 +240,9 @@ func (d domainProxy) Min(s Store) (int, bool) {
 	return d.Domain(s).Min()
 }
 
-func (d domainProxy) Remove(values ...int) Change {
+func (d domainProxy) Remove(values []int) Change {
 	return func(s Store) {
-		d.domain.Set(d.Domain(s).Remove(values...))(s)
+		d.domain.Set(d.Domain(s).Remove(values))(s)
 	}
 }
 

--- a/store/domains.go
+++ b/store/domains.go
@@ -108,10 +108,10 @@ type Domains interface {
 
 			s1 := store.New()
 			d := store.NewDomains(s1, model.Multiple(42, 13)) // {13, 42}
-			s2 := s1.Apply(d.Remove(0, 13))
+			s2 := s1.Apply(d.Remove(0, []int{13}))
 			d.Domains(s2) // {42}
 	*/
-	Remove(int, ...int) Change
+	Remove(int, []int) Change
 
 	/*
 		Singleton is true if all Domains are Singleton.
@@ -319,9 +319,9 @@ func (d domainsProxy) Len(s Store) int {
 	return d.Domains(s).Len()
 }
 
-func (d domainsProxy) Remove(i int, v ...int) Change {
+func (d domainsProxy) Remove(i int, v []int) Change {
 	return func(s Store) {
-		d.domains.Set(d.domains.Get(s).Remove(i, v...))(s)
+		d.domains.Set(d.domains.Get(s).Remove(i, v))(s)
 	}
 }
 

--- a/store/example_domain_test.go
+++ b/store/example_domain_test.go
@@ -111,7 +111,7 @@ func ExampleDomain_min() {
 func ExampleDomain_remove() {
 	s1 := store.New()
 	d := store.NewDomain(s1, model.NewRange(1, 5))
-	s2 := s1.Apply(d.Remove(2, 4))
+	s2 := s1.Apply(d.Remove([]int{2, 4}))
 	fmt.Println(d.Domain(s1))
 	fmt.Println(d.Domain(s2))
 	// Output:

--- a/store/example_domains_test.go
+++ b/store/example_domains_test.go
@@ -89,7 +89,7 @@ func ExampleDomains_len() {
 func ExampleDomains_remove() {
 	s1 := store.New()
 	d := store.NewDomains(s1, model.Multiple(42, 13))
-	s2 := s1.Apply(d.Remove(0, 13))
+	s2 := s1.Apply(d.Remove(0, []int{13}))
 	fmt.Println(d.Domains(s2))
 	// Output:
 	// [{[{42 42}]}]


### PR DESCRIPTION
# Description

This PR changes the signature of the `Remove` function for `model.Domain` and `model.Domains` from using variadic to a fixed slice to avoid unexpected behavior. This behavior could occur when _no_ values to be removed where passed at all (per signature of the function this is valid), but hard to detect by the user.

## Changes
- Changes the signatures in model/`model.go`, store/`domain.go` and store/`domains.go`
- Updates `tests` to adhere to new signatures