### PR TITLE
Add support for build tag "debug"

### DIFF
--- a/plugin/connect.go
+++ b/plugin/connect.go
@@ -83,12 +83,13 @@ func potentialPluginPaths(slug string) ([]string, error) {
 
 	// Assemble potential plugin paths
 	filename := fmt.Sprintf(
-		"nextmv-%s-%s-%s-%s-%s.so",
+		"nextmv-%s-%s-%s-%s-%s%s.so",
 		slug,
 		sdk.VERSION,
 		runtime.Version(),
 		runtime.GOOS,
 		runtime.GOARCH,
+		debug,
 	)
 	paths := []string{
 		filepath.Join(cwd, filename),

--- a/plugin/file_suffix_debug.go
+++ b/plugin/file_suffix_debug.go
@@ -1,0 +1,5 @@
+//go:build debug
+
+package plugin
+
+const debug = "-debug"

--- a/plugin/file_suffix_prod.go
+++ b/plugin/file_suffix_prod.go
@@ -1,0 +1,5 @@
+//go:build !debug
+
+package plugin
+
+const debug = ""


### PR DESCRIPTION
## Description

We are building plugins with and without debug flags. This PR adds support to use one or the other version as a user of SDK. When a user wants to debug, they provide `-tags=debug` as their `buildflags` for example in their VsCode launch configuration (this will already be set in the workspace files of `nextmv-cli` templates).