### PR TITLE
ENG-1600 Fix breaking tests

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -1,7 +1,7 @@
 name: go build & test
 on: [push]
 jobs:
-  sdk:
+  sdk-go-build-test:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/nextmv-io/*
@@ -59,22 +59,12 @@ jobs:
           # replaced for the local sdk repo checked out in this action.
           go mod edit -replace=github.com/nextmv-io/sdk=${{env.SDK_PATH}}
 
-          # Create the path where the shared object binaries are going to be
-          # saved.
-          VERSION=$(go run cmd/version/main.go)
-          GOVERSION=$(go env GOVERSION)
-          GOOS=$(go env GOOS)
-          GOARCH=$(go env GOARCH)
-          OUT_PATH=${{env.NEXTMV_LIBRARY_PATH}}/nextmv-sdk-$VERSION-$GOVERSION-$GOOS-$GOARCH.so
-
-          # Build without -trimpath because the sdk dependency is being
-          # replaced for the local sdk repo used in the action.
-          cd plugins/sdk
-          go build -buildmode plugin -o $OUT_PATH
+          # Build the plugins.
+          REMOVE_TRIMPATH=1 NEXTMV_LIBRARY_PATH=${{ env.NEXTMV_LIBRARY_PATH }} bash scripts/build.sh
         working-directory: ${{env.RESOURCES}}
 
       - name: go build
         run: go build -v ./...
 
       - name: go test
-        run: NEXTMV_LIBRARY_PATH=${{ env.NEXTMV_LIBRARY_PATH }} NEXTMV_TOKEN=$(nextmv token) go test -v ./...
+        run: NEXTMV_LIBRARY_PATH=${{ env.NEXTMV_LIBRARY_PATH }} NEXTMV_TOKEN=$(nextmv token) go test ./...

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,7 +1,7 @@
 name: go lint
 on: [push]
 jobs:
-  sdk:
+  sdk-go-lint:
     runs-on: ubuntu-latest
     steps:
       - name: set up go

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,21 +1,14 @@
 name: markdown lint
 on: [push]
 jobs:
-  sdk:
+  sdk-markdown-lint:
     runs-on: ubuntu-latest
     steps:
+      # Checkout the changes
       - name: git clone
         uses: actions/checkout@v3
 
-      - name: set up Node.js
-        uses: actions/setup-node@v3
+      # Use markdownlint-cli2
+      - uses: DavidAnson/markdownlint-cli2-action@v7
         with:
-          node-version: "14"
-
-      - name: install markdownlint-cli2
-        run: |
-          npm install markdownlint-cli2 --global
-
-      - name: run markdownlint-cli2
-        run: |
-          markdownlint-cli2 "**/*.md"
+          globs: "**/*.md"

--- a/mip/example_objective_test.go
+++ b/mip/example_objective_test.go
@@ -52,11 +52,11 @@ func ExampleObjective_terms() {
 
 	terms := model.Objective().Terms()
 	fmt.Println(len(terms))
-	fmt.Println(terms[0].Coefficient())
-	fmt.Println(model.Objective().IsMaximize())
-	fmt.Println(terms[0])
-	fmt.Println(terms[1])
-	// Output:
+	for _, term := range terms {
+		fmt.Println(term.Var(), term.Coefficient())
+	}
+	fmt.Println("isMaximize: ", model.Objective().IsMaximize())
+	// Unordered output:
 	// 0
 	// 2 B0
 	// 1 B0
@@ -68,10 +68,9 @@ func ExampleObjective_terms() {
 	// 1
 	// 3
 	// 2
-	// 3
-	// false
-	// 3 B0
-	// 3 B1
+	// B0 3
+	// B1 3
+	// isMaximize:  false
 }
 
 func benchmarkObjectiveNewTerms(nrTerms int, b *testing.B) {

--- a/store/example_knights_tour_test.go
+++ b/store/example_knights_tour_test.go
@@ -171,6 +171,7 @@ func Example_knightsTour() {
 	// are needed, there is no value associated.
 	opt := store.DefaultOptions()
 	opt.Limits.Solutions = 1
+	opt.Diagram.Expansion.Limit = 1
 	solver := knight.Satisfier(opt)
 
 	// Get the last solution of the problem and print it.
@@ -182,10 +183,10 @@ func Example_knightsTour() {
 	fmt.Println(string(b))
 	// Output:
 	// {
-	//   "0": "00 17 06 11 20 ",
-	//   "1": "07 12 19 16 05 ",
-	//   "2": "18 01 04 21 10 ",
-	//   "3": "13 08 23 02 15 ",
-	//   "4": "24 03 14 09 22 "
+	//   "0": "00 21 10 15 06 ",
+	//   "1": "11 16 07 20 09 ",
+	//   "2": "24 01 22 05 14 ",
+	//   "3": "17 12 03 08 19 ",
+	//   "4": "02 23 18 13 04 "
 	// }
 }

--- a/store/example_store_test.go
+++ b/store/example_store_test.go
@@ -580,6 +580,7 @@ func ExampleStore_satisfier() {
 	x := store.NewVar(s, 100)
 	opt := store.DefaultOptions()
 	opt.Limits.Solutions = 1
+	opt.Diagram.Expansion.Limit = 1
 	satisfier := s.
 		Format(func(s store.Store) any { return x.Get(s) }).
 		Validate(func(s store.Store) bool {
@@ -607,5 +608,5 @@ func ExampleStore_satisfier() {
 	}
 	fmt.Println(string(b))
 	// Output:
-	// 90
+	// 96
 }


### PR DESCRIPTION
# Description

Changes a `mip` test for the `Unordered output` to test content, not ordering. Makes satisfier examples consistent by setting an expansion limit. Adds some changes to the actions for consistency with documentation repo.