### PR TITLE
Feature/eng 1675 letter case for constants

### DIFF
--- a/mip/example_solveoptions_test.go
+++ b/mip/example_solveoptions_test.go
@@ -23,7 +23,7 @@ func ExampleSolveOptions_default() {
 
 func ExampleSolveOptions_change() {
 	solveOptions := mip.NewSolveOptions()
-	solveOptions.SetVerbosity(mip.HIGH)
+	solveOptions.SetVerbosity(mip.High)
 	err := solveOptions.SetMIPGapAbsolute(1.23)
 	if err != nil {
 		panic(err)

--- a/mip/solver.go
+++ b/mip/solver.go
@@ -80,16 +80,16 @@ type SolveOptions interface {
 type Verbosity int
 
 const (
-	// OFF logs nothing.
-	OFF Verbosity = iota
-	// LOW logs essentials, depends on the back-end solver.
-	LOW
-	// MEDIUM logs essentials plus high level events,
+	// Off logs nothing.
+	Off Verbosity = iota
+	// Low logs essentials, depends on the back-end solver.
+	Low
+	// Medium logs essentials plus high level events,
 	// depends on the back-end solver.
-	MEDIUM
-	// HIGH logs everything the underlying logs,
+	Medium
+	// High logs everything the underlying logs,
 	// depends on the back-end solver.
-	HIGH
+	High
 )
 
 // SolverParameter identifier for parameters in the back-end solver.


### PR DESCRIPTION
This changes the all caps mip constants to letter case to be closer to Go's generic style guide.