### PR TITLE
feature/eng-2047-remove-with-lfs-from-workflows

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -60,8 +60,6 @@ jobs:
 
       - name: git clone
         uses: actions/checkout@v3
-        with:
-          lfs: true
 
       - name: clone platform repository 
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

This PR removes the `with lfs` option for cloning repositories that do not need it.

## Changes

* build-workflow for GH