### PR TITLE
feature/eng-2033-expose-multiple-hard-windows-per-stop-in

### DIFF
--- a/route/example_option_test.go
+++ b/route/example_option_test.go
@@ -1251,6 +1251,192 @@ func ExampleWindows() {
 	// }
 }
 
+// Create routes to visit seven landmarks in Kyoto using two vehicles with
+// mutiple time windows. The stops have time windows.
+func ExampleMultiWindows() {
+	// Define stops and vehicles.
+	stops := []route.Stop{
+		{
+			ID:       "Fushimi Inari Taisha",
+			Position: route.Position{Lon: 135.772695, Lat: 34.967146},
+		},
+		{
+			ID:       "Kiyomizu-dera",
+			Position: route.Position{Lon: 135.785060, Lat: 34.994857},
+		},
+		{
+			ID:       "Nijō Castle",
+			Position: route.Position{Lon: 135.748134, Lat: 35.014239},
+		},
+		{
+			ID:       "Kyoto Imperial Palace",
+			Position: route.Position{Lon: 135.762057, Lat: 35.025431},
+		},
+		{
+			ID:       "Gionmachi",
+			Position: route.Position{Lon: 135.775682, Lat: 35.002457},
+		},
+		{
+			ID:       "Kinkaku-ji",
+			Position: route.Position{Lon: 135.728898, Lat: 35.039705},
+		},
+		{
+			ID:       "Arashiyama Bamboo Forest",
+			Position: route.Position{Lon: 135.672009, Lat: 35.017209},
+		},
+	}
+	vehicles := []string{
+		"v1",
+		"v2",
+	}
+
+	serviceTimes := []route.Service{
+		{
+			ID:       "Gionmachi",
+			Duration: 900,
+		},
+	}
+
+	// Define time windows for every stop.
+	windows := [][]route.TimeWindow{
+		{
+			{
+				Start: time.Date(2020, 10, 17, 7, 0, 0, 0, time.UTC),
+				End:   time.Date(2020, 10, 17, 10, 0, 0, 0, time.UTC),
+			},
+			{
+				Start: time.Date(2020, 10, 17, 13, 0, 0, 0, time.UTC),
+				End:   time.Date(2020, 10, 17, 17, 0, 0, 0, time.UTC),
+			},
+		},
+		{},
+		{},
+		{},
+		{},
+		{},
+		{},
+	}
+
+	maxWaitTimes := []int{900, 0, 0, 0, 0, 0, 0, 0}
+
+	// Define shifts for every vehicle
+	shifts := []route.TimeWindow{
+		{
+			Start: time.Date(2020, 10, 17, 9, 0, 0, 0, time.UTC),
+			End:   time.Date(2020, 10, 17, 17, 0, 0, 0, time.UTC),
+		},
+		{
+			Start: time.Date(2020, 10, 17, 9, 0, 0, 0, time.UTC),
+			End:   time.Date(2020, 10, 17, 17, 0, 0, 0, time.UTC),
+		},
+	}
+	// Declare the router and its solver.
+	router, err := route.NewRouter(
+		stops,
+		vehicles,
+		route.Services(serviceTimes),
+		route.Shifts(shifts),
+		route.MultiWindows(windows, maxWaitTimes),
+		route.Threads(1),
+	)
+	if err != nil {
+		panic(err)
+	}
+	solver, err := router.Solver(store.DefaultOptions())
+	if err != nil {
+		panic(err)
+	}
+
+	// Get the last solution of the problem and print it.
+	last := solver.Last(context.Background())
+	b, err := json.MarshalIndent(last.Store, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+	// Output:
+	// {
+	//   "unassigned": [],
+	//   "vehicles": [
+	//     {
+	//       "id": "v1",
+	//       "route": [
+	//         {
+	//           "id": "Kinkaku-ji",
+	//           "position": {
+	//             "lon": 135.728898,
+	//             "lat": 35.039705
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:00:00Z",
+	//           "estimated_departure": "2020-10-17T09:00:00Z"
+	//         },
+	//         {
+	//           "id": "Nijō Castle",
+	//           "position": {
+	//             "lon": 135.748134,
+	//             "lat": 35.014239
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:05:33Z",
+	//           "estimated_departure": "2020-10-17T09:05:33Z"
+	//         },
+	//         {
+	//           "id": "Kyoto Imperial Palace",
+	//           "position": {
+	//             "lon": 135.762057,
+	//             "lat": 35.025431
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:08:31Z",
+	//           "estimated_departure": "2020-10-17T09:08:31Z"
+	//         },
+	//         {
+	//           "id": "Gionmachi",
+	//           "position": {
+	//             "lon": 135.775682,
+	//             "lat": 35.002457
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:13:15Z",
+	//           "estimated_departure": "2020-10-17T09:28:15Z"
+	//         },
+	//         {
+	//           "id": "Kiyomizu-dera",
+	//           "position": {
+	//             "lon": 135.78506,
+	//             "lat": 34.994857
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:30:15Z",
+	//           "estimated_departure": "2020-10-17T09:30:15Z"
+	//         },
+	//         {
+	//           "id": "Fushimi Inari Taisha",
+	//           "position": {
+	//             "lon": 135.772695,
+	//             "lat": 34.967146
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:35:43Z",
+	//           "estimated_departure": "2020-10-17T09:35:43Z"
+	//         }
+	//       ],
+	//       "route_duration": 2143
+	//     },
+	//     {
+	//       "id": "v2",
+	//       "route": [
+	//         {
+	//           "id": "Arashiyama Bamboo Forest",
+	//           "position": {
+	//             "lon": 135.672009,
+	//             "lat": 35.017209
+	//           },
+	//           "estimated_arrival": "2020-10-17T09:00:00Z",
+	//           "estimated_departure": "2020-10-17T09:00:00Z"
+	//         }
+	//       ],
+	//       "route_duration": 0
+	//     }
+	//   ]
+	// }
+}
+
 // Create routes to visit seven landmarks in Kyoto using two vehicles. One
 // vehicle has a backlog.
 func ExampleBacklogs() {

--- a/route/example_option_test.go
+++ b/route/example_option_test.go
@@ -1317,7 +1317,7 @@ func ExampleMultiWindows() {
 		{},
 	}
 
-	maxWaitTimes := []int{900, 0, 0, 0, 0, 0, 0, 0}
+	maxWaitTimes := []int{900, 0, 0, 0, 0, 0, 0}
 
 	// Define shifts for every vehicle
 	shifts := []route.TimeWindow{

--- a/route/option.go
+++ b/route/option.go
@@ -86,6 +86,19 @@ func Windows(windows []Window) Option {
 	return windowsFunc(windows)
 }
 
+// MultiWindows adds a time window constraint to the list of constraints. The
+// method takes in multiple windows per stop, which are indexed by stop and
+// represent several fixed time frames in which the stop must be served.
+// Furthermore, a wait time per stop must be specified where -1 means that a
+// vehicle may wait indefinitely until a window opens. Service times at the
+// stops can be optionally added using the Services option.
+//
+// PLEASE NOTE: this option requires using the Shift option.
+func MultiWindows(windows [][]TimeWindow, maxWaitTimes []int) Option {
+	connect.Connect(con, &multiWindowsFunc)
+	return multiWindowsFunc(windows, maxWaitTimes)
+}
+
 // Unassigned sets the unassigned penalties indexed by stop. The length must
 // match the stops' length.
 func Unassigned(penalties []int) Option {
@@ -369,6 +382,7 @@ var (
 	servicesFunc              func([]Service) Option
 	shiftsFunc                func([]TimeWindow) Option
 	windowsFunc               func([]Window) Option
+	multiWindowsFunc          func([][]TimeWindow, []int) Option
 	unassignedFunc            func([]int) Option
 	backlogsFunc              func([]Backlog) Option
 	minimizeFunc              func() Option


### PR DESCRIPTION
# Description

This PR adds a new option to the routing engine that allows to use multiple time windows per stop. It can be use instead of the previously Windows option but cannot be combined with it.

## Changes

* option.go -> new option is added
* example_option_test.go -> an example how to use the option is added.