### PR TITLE
feature/eng-2533-bug-with-measure-matrix-sdk-functions

### DIFF
--- a/route/here/measure.go
+++ b/route/here/measure.go
@@ -95,12 +95,14 @@ func NewClient(apiKey string, opts ...ClientOption) Client {
 }
 
 func cleanPoints(points []route.Point) []route.Point {
-	for i, p := range points {
+	cleanPoints := make([]route.Point, len(points))
+	copy(cleanPoints, points)
+	for i, p := range cleanPoints {
 		if len(p) == 2 && p[0] == 0 && p[1] == 0 {
-			points[i] = route.Point{}
+			cleanPoints[i] = route.Point{}
 		}
 	}
-	return points
+	return cleanPoints
 }
 
 // DistanceMatrix retrieves a HERE distance matrix. It uses the async HERE API

--- a/route/here/measure.go
+++ b/route/here/measure.go
@@ -94,6 +94,15 @@ func NewClient(apiKey string, opts ...ClientOption) Client {
 	return c
 }
 
+func cleanPoints(points []route.Point) []route.Point {
+	for i, p := range points {
+		if len(p) == 2 && p[0] == 0 && p[1] == 0 {
+			points[i] = route.Point{}
+		}
+	}
+	return points
+}
+
 // DistanceMatrix retrieves a HERE distance matrix. It uses the async HERE API
 // if there are more than 500 points given.
 func (c *client) DistanceMatrix(
@@ -101,6 +110,7 @@ func (c *client) DistanceMatrix(
 	points []route.Point,
 	opts ...MatrixOption,
 ) (route.ByIndex, error) {
+	points = cleanPoints(points)
 	if len(points) > c.maxSyncPoints {
 		distances, _, err := c.fetchMatricesAsync(ctx, points, true, false, opts)
 		return distances, err
@@ -116,6 +126,7 @@ func (c *client) DurationMatrix(
 	points []route.Point,
 	opts ...MatrixOption,
 ) (route.ByIndex, error) {
+	points = cleanPoints(points)
 	if len(points) > c.maxSyncPoints {
 		_, durations, err := c.fetchMatricesAsync(
 			ctx, points, false, true, opts)
@@ -132,6 +143,7 @@ func (c *client) DistanceDurationMatrices(
 	points []route.Point,
 	opts ...MatrixOption,
 ) (distances, durations route.ByIndex, err error) {
+	points = cleanPoints(points)
 	if len(points) > c.maxSyncPoints {
 		return c.fetchMatricesAsync(ctx, points, true, true, opts)
 	}


### PR DESCRIPTION
# Description

This PR makes the HERE client more robust when a Point of (0,0) is passed. Now those points are interpreted correctly as points that do not need to be routed and a cost of 0 is returned when going to or coming from such a point.

## Changes

- `here/measure.go`