### PR TITLE
feature/eng-2552-http-runner-is-defaulting-to-all

### DIFF
--- a/run/http_runner_config.go
+++ b/run/http_runner_config.go
@@ -10,7 +10,7 @@ type HTTPRunnerConfig struct {
 	Runner struct {
 		Log    *log.Logger
 		Output struct {
-			Solutions string `default:"all" usage:"Return all or last solution"`
+			Solutions string `default:"last" usage:"Return all or last solution"`
 			Quiet     bool   `default:"false" usage:"Do not return statistics"`
 		}
 		HTTP struct {


### PR DESCRIPTION
# Decription

This PR sets the default for solution output to `last` instead of `all` for http runners.

# Changes

- `http_runner_config.go` to set the new default value