### PR TITLE
ENG-2704 Enable creation of invalid locations

### DIFF
--- a/nextroute/common/fast_haversine.go
+++ b/nextroute/common/fast_haversine.go
@@ -38,7 +38,7 @@ func wrap(deg float64) float64 {
 
 // Distance returns the distance between two locations in meters.
 func (f FastHaversine) Distance(from, to Location) float64 {
-	if !from.valid || !to.valid {
+	if !from.IsValid() || !to.IsValid() {
 		return 0.0
 	}
 	dx := wrap(from.Longitude()-to.Longitude()) * f.kx

--- a/nextroute/common/fast_haversine.go
+++ b/nextroute/common/fast_haversine.go
@@ -1,6 +1,9 @@
 package common
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // NewFastHaversine returns a new FastHaversine.
 func NewFastHaversine(lat float64) FastHaversine {
@@ -37,11 +40,20 @@ func wrap(deg float64) float64 {
 }
 
 // Distance returns the distance between two locations in meters.
-func (f FastHaversine) Distance(from, to Location) float64 {
+func (f FastHaversine) Distance(from, to Location) (float64, error) {
 	if !from.IsValid() || !to.IsValid() {
-		return 0.0
+		return 0.0,
+			fmt.Errorf(
+				"from (%f, %f) (valid = %t) or to (%f, %f) (valid = %t) is invalid",
+				from.Longitude(),
+				from.Latitude(),
+				from.IsValid(),
+				to.Longitude(),
+				to.Latitude(),
+				to.IsValid(),
+			)
 	}
 	dx := wrap(from.Longitude()-to.Longitude()) * f.kx
 	dy := (from.Latitude() - to.Latitude()) * f.ky
-	return math.Sqrt(dx*dx + dy*dy)
+	return math.Sqrt(dx*dx + dy*dy), nil
 }

--- a/nextroute/common/haversine.go
+++ b/nextroute/common/haversine.go
@@ -1,15 +1,17 @@
 package common
 
 import (
+	"fmt"
 	"math"
 )
 
 // Haversine calculates the distance between two locations using the
 // Haversine formula. Haversine is a good approximation for short
 // distances (up to a few hundred kilometers).
-func Haversine(from, to Location) Distance {
+func Haversine(from, to Location) (Distance, error) {
 	if !from.valid || !to.valid {
-		return NewDistance(0, Meters)
+		return Distance{},
+			fmt.Errorf("from (%v) or to (%v) are invalid", from.valid, to.valid)
 	}
 
 	x1 := degreesToRadian(from.Longitude())
@@ -27,7 +29,7 @@ func Haversine(from, to Location) Distance {
 	return NewDistance(
 		2*radius*math.Atan2(math.Sqrt(a), math.Sqrt(1-a)),
 		Meters,
-	)
+	), nil
 }
 
 func degreesToRadian(d float64) float64 {

--- a/nextroute/common/haversine.go
+++ b/nextroute/common/haversine.go
@@ -9,9 +9,9 @@ import (
 // Haversine formula. Haversine is a good approximation for short
 // distances (up to a few hundred kilometers).
 func Haversine(from, to Location) (Distance, error) {
-	if !from.valid || !to.valid {
+	if !from.IsValid() || !to.IsValid() {
 		return Distance{},
-			fmt.Errorf("from (%v) or to (%v) are invalid", from.valid, to.valid)
+			fmt.Errorf("from (%v) or to (%v) are invalid", from.IsValid(), to.IsValid())
 	}
 
 	x1 := degreesToRadian(from.Longitude())

--- a/nextroute/common/location.go
+++ b/nextroute/common/location.go
@@ -49,14 +49,23 @@ func (l Locations) Unique() Locations {
 }
 
 // Centroid returns the centroid of the locations. If locations is empty, the
-// centroid will be (0, 0).
+// centroid will be an invalid location.
 func (l Locations) Centroid() (Location, error) {
 	if len(l) == 0 {
-		return NewLocation(0, 0)
+		return NewInvalidLocation(), nil
 	}
 	lat := 0.0
 	lon := 0.0
-	for _, location := range l {
+	for l, location := range l {
+		if !location.IsValid() {
+			return NewInvalidLocation(),
+				fmt.Errorf(
+					"location %d (%f, %f) is invalid",
+					l,
+					location.Longitude(),
+					location.Latitude(),
+				)
+		}
 		lat += location.Latitude()
 		lon += location.Longitude()
 	}

--- a/nextroute/common/location.go
+++ b/nextroute/common/location.go
@@ -24,6 +24,14 @@ func NewLocation(
 	}
 }
 
+// NewInvalidLocation creates a new invalid Location. Longitude and latitude
+// are not important.
+func NewInvalidLocation() Location {
+	return Location{
+		valid: false,
+	}
+}
+
 // Locations is a slice of Location.
 type Locations []Location
 

--- a/nextroute/common/location.go
+++ b/nextroute/common/location.go
@@ -4,30 +4,28 @@ import (
 	"fmt"
 )
 
-// NewLocation creates a new Location. Will panic if longitude or latitude are
-// out of range. Longitude must be between -180 and 180. Latitude must be
-// between -90 and 90.
-func NewLocation(
-	longitude float64,
-	latitude float64,
-) Location {
+// NewLocation creates a new Location. An error is returned if the longitude is
+// not between (-180, 180) or the latitude is not between (-90, 90).
+func NewLocation(longitude float64, latitude float64) (Location, error) {
 	if longitude < -180 || longitude > 180 {
-		panic("longitude must be between -180 and 180")
+		return NewInvalidLocation(),
+			fmt.Errorf("longitude %f must be between -180 and 180", longitude)
 	}
 	if latitude < -90 || latitude > 90 {
-		panic("latitude must be between -90 and 90")
+		return NewInvalidLocation(),
+			fmt.Errorf("latitude %f must be between -90 and 90", latitude)
 	}
-	return Location{
+	return location{
 		longitude: longitude,
 		latitude:  latitude,
 		valid:     true,
-	}
+	}, nil
 }
 
 // NewInvalidLocation creates a new invalid Location. Longitude and latitude
 // are not important.
 func NewInvalidLocation() Location {
-	return Location{
+	return location{
 		valid: false,
 	}
 }
@@ -52,27 +50,41 @@ func (l Locations) Unique() Locations {
 
 // Centroid returns the centroid of the locations. If locations is empty, the
 // centroid will be (0, 0).
-func (l Locations) Centroid() Location {
+func (l Locations) Centroid() (Location, error) {
 	if len(l) == 0 {
 		return NewLocation(0, 0)
 	}
 	lat := 0.0
 	lon := 0.0
 	for _, location := range l {
-		lat += location.latitude
-		lon += location.longitude
+		lat += location.Latitude()
+		lon += location.Longitude()
 	}
 	return NewLocation(lon/float64(len(l)), lat/float64(len(l)))
 }
 
-// Location represents a location on the earth.
-type Location struct {
+// Location represents a physical location on the earth.
+type Location interface {
+	// Longitude returns the longitude of the location.
+	Longitude() float64
+	// Latitude returns the latitude of the location.
+	Latitude() float64
+	// Equals returns true if the location is equal to the location given as an
+	// argument.
+	Equals(Location) bool
+	// IsValid returns true if the location is valid. A location is valid if
+	// the bounds of the longitude and latitude are correct.
+	IsValid() bool
+}
+
+// Implements Location.
+type location struct {
 	longitude float64
 	latitude  float64
 	valid     bool
 }
 
-func (l Location) String() string {
+func (l location) String() string {
 	return fmt.Sprintf(
 		"{lat: %v,lon: %v}",
 		l.latitude,
@@ -80,18 +92,18 @@ func (l Location) String() string {
 	)
 }
 
-func (l Location) Longitude() float64 {
+func (l location) Longitude() float64 {
 	return l.longitude
 }
 
-func (l Location) Latitude() float64 {
+func (l location) Latitude() float64 {
 	return l.latitude
 }
 
-func (l Location) Equals(other Location) bool {
-	return l.longitude == other.longitude && l.latitude == other.latitude
+func (l location) Equals(other Location) bool {
+	return l.longitude == other.Longitude() && l.latitude == other.Latitude()
 }
 
-func (l Location) IsValid() bool {
+func (l location) IsValid() bool {
 	return l.valid
 }

--- a/nextroute/common/utils.go
+++ b/nextroute/common/utils.go
@@ -33,6 +33,21 @@ func Unique[T comparable](s []T) []T {
 	return result
 }
 
+// UniqueDefined is a universal duplicate removal function for type instances in
+// a slice that implement the comparable interface. The function f is used to
+// extract the comparable value from the type instance.
+func UniqueDefined[T any, I comparable](items []T, f func(T) I) []T {
+	inResult := make(map[I]bool)
+	var result []T
+	for _, item := range items {
+		if _, ok := inResult[f(item)]; !ok {
+			inResult[f(item)] = true
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
 // GroupBy groups the elements of a slice by a key function.
 func GroupBy[T any, K comparable](s []T, f func(T) K) map[K][]T {
 	inResult := make(map[K]bool)

--- a/nextroute/engine.go
+++ b/nextroute/engine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nextmv-io/sdk/connect"
 	"github.com/nextmv-io/sdk/measure"
 	"github.com/nextmv-io/sdk/nextroute/common"
+	"github.com/nextmv-io/sdk/nextroute/schema"
 )
 
 var (
@@ -89,8 +90,12 @@ var (
 	newMeasureByPointExpression func(
 		measure.ByPoint,
 	) ModelExpression
-	newModel                func() (Model, error)
-	newModelFactory         func() ModelFactory
+	newModel   func() (Model, error)
+	buildModel func(
+		schema.Input,
+		ModelOptions,
+		...Option,
+	) (Model, error)
 	newModelConstraintIndex func() int
 	newModelExpressionIndex func() int
 	newModelObjectiveIndex  func() int

--- a/nextroute/model.go
+++ b/nextroute/model.go
@@ -9,21 +9,21 @@ import (
 	"github.com/nextmv-io/sdk/nextroute/schema"
 )
 
-// ModelFactory creates a new model.
-type ModelFactory interface {
-	NewModel(schema.Input, ModelOptions, ...Option) (Model, error)
-}
-
-// NewModelFactory creates a new model factory.
-func NewModelFactory() ModelFactory {
-	connect.Connect(con, &newModelFactory)
-	return newModelFactory()
-}
-
-// NewModel creates a new model. The model is used to define a routing problem.
+// NewModel creates a new empty vehicle routing model. Please use [BuildModel]
+// if you want a model which already has all features added to it.
 func NewModel() (Model, error) {
 	connect.Connect(con, &newModel)
 	return newModel()
+}
+
+// BuildModel builds a ready-to-go vehicle routing problem. The difference with
+// [NewModel] is that BuildModel processes the input and options to add all
+// features to the model, such as constraints and objectives. On the other
+// hand, [NewModel] creates an empty vehicle routing model which must be built
+// from the ground up.
+func BuildModel(i schema.Input, m ModelOptions, opts ...Option) (Model, error) {
+	connect.Connect(con, &buildModel)
+	return buildModel(i, m, opts...)
 }
 
 // ModelOptions represents options for a model.

--- a/nextroute/model_expression.go
+++ b/nextroute/model_expression.go
@@ -20,6 +20,9 @@ type ModelExpression interface {
 	// Value returns the value of the expression for the given vehicle type,
 	// from stop and to stop.
 	Value(ModelVehicleType, ModelStop, ModelStop) float64
+
+	// SetName sets the name of the expression.
+	SetName(string)
 }
 
 // ModelExpressions is a slice of ModelExpression.

--- a/nextroute/model_plancluster.go
+++ b/nextroute/model_plancluster.go
@@ -20,7 +20,7 @@ type ModelPlanCluster interface {
 
 	// Centroid returns the centroid of the cluster. The centroid is the
 	// average location of all stops in the cluster.
-	Centroid() common.Location
+	Centroid() (common.Location, error)
 
 	// Index returns the index of the cluster.
 	Index() int

--- a/nextroute/solution_vehicle.go
+++ b/nextroute/solution_vehicle.go
@@ -24,7 +24,7 @@ type SolutionVehicle interface {
 	// Centroid returns the centroid of the vehicle. The centroid is the
 	// average location of all stops in the vehicle excluding the start and
 	// end stops.
-	Centroid() common.Location
+	Centroid() (common.Location, error)
 
 	// Duration returns the duration of the vehicle. The duration is the
 	// time the vehicle is on the road. The duration is the time between


### PR DESCRIPTION
# Description

Regarding the use of `Location`:
- Create the `NewInvalidLocation` function to enable the creation of invalid locations. 
- Modify the `NewLocation` function to also return an error.
- Change `Location` to be an interface, to avoid having two ways to instantiate a new `Location`. Now, only `NewLocation` or `NewInvalidLocation` may be used.
- Change signatures of functions that rely on `NewLocation` and `NewInvalidLocation` to return an error as well.

Regarding building a new `Model`:
- Creates the function `BuildModel` to return a ready-to-go `Model`.
- Deletes the factory logic.
- Enables the `SetName` method on the `ModelExpression` interface to allow custom naming of default expressions. This is used to add the vehicle's ID when using a TravelDurationExpression.

Regarding `common`:
- Added the `UniqueDefined` func to allow unique comparisons on interface types.