### PR TITLE
ENG-2761 Create the shift constraint

### DIFF
--- a/nextroute/model.go
+++ b/nextroute/model.go
@@ -141,4 +141,8 @@ type Model interface {
 
 	// Vehicle returns the vehicle with the specified index.
 	Vehicle(index int) ModelVehicle
+
+	// SetEpoch sets the epoch of the model. You can use [Epoch] to get the
+	// epoch of the model.
+	SetEpoch(time.Time)
 }


### PR DESCRIPTION
# Description

Enables the `SetEpoch` method on the model to be able to customize the model's epoch.