### PR TITLE
ModelOptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -195,7 +195,20 @@ issues:
     - path: nextroute/model\.go
       linters:
         - lll
-
+    # Complexity in NewAlias is high due to multiple cases, fine for now.
+    - path: nextroute/common/alias\.go
+      linters:
+        - gocyclo
+    # Complexity in statistics is high due to multiple cases, fine for now.
+    - path: nextroute/common/statistics\.go
+      linters:
+        - gocyclo
+    - path: nextroute/common/statistics_test\.go
+      linters:
+        - gocyclo
+    - path: nextroute/common/nsmallest_test\.go
+      linters:
+        - gocyclo
     # Complexity in UnmarshalJSON is high due to multiple cases, fine for now.
     - path: route/load\.go
       linters:

--- a/nextroute/common/alias.go
+++ b/nextroute/common/alias.go
@@ -57,7 +57,7 @@ func NewAlias(weights []float64) (Alias, error) {
 
 	multiplier := float64(n) / sum
 	for i, weight := range weights {
-		weight = weight * multiplier
+		weight *= multiplier
 		if weight >= 1 {
 			largeBottom--
 			twins[largeBottom] = float64PieceImpl{

--- a/nextroute/common/alias_test.go
+++ b/nextroute/common/alias_test.go
@@ -1,14 +1,17 @@
 package common_test
 
 import (
-	"github.com/nextmv-io/sdk/nextroute/common"
 	"math"
 	"math/rand"
 	"testing"
+
+	"github.com/nextmv-io/sdk/nextroute/common"
 )
 
-const samples = 1_000_000
-const errorEpsilon = 0.001
+const (
+	samples      = 1_000_000
+	errorEpsilon = 0.001
+)
 
 func TestAlias(t *testing.T) {
 	testAlias(t, []float64{2, 2}, 22)

--- a/nextroute/common/distance.go
+++ b/nextroute/common/distance.go
@@ -44,6 +44,7 @@ const (
 	factorMilesToMeters      = 1609.34
 )
 
+// String returns the string representation of the distance unit.
 func (d DistanceUnit) String() string {
 	switch d {
 	case Kilometers:
@@ -56,11 +57,13 @@ func (d DistanceUnit) String() string {
 	return fmt.Sprintf("unknown distance unit %v", int(d))
 }
 
+// Distance is a distance in a given unit.
 type Distance struct {
 	meters float64
 	unit   DistanceUnit
 }
 
+// Value returns the distance in the specified unit.
 func (d Distance) Value(unit DistanceUnit) float64 {
 	returnValue := d.meters
 	switch unit {

--- a/nextroute/common/nsmallest.go
+++ b/nextroute/common/nsmallest.go
@@ -46,6 +46,7 @@ type minHeap[T any] []itemValue[T]
 func (h minHeap[T]) Len() int {
 	return len(h)
 }
+
 func (h minHeap[T]) Less(i, j int) bool {
 	return h[i].value < h[j].value
 }
@@ -65,6 +66,7 @@ func (h *minHeap[T]) Pop() interface{} {
 	*h = old[0 : n-1]
 	return x
 }
+
 func (h *minHeap[T]) Peek() itemValue[T] {
 	return (*h)[0]
 }

--- a/nextroute/common/nsmallest_test.go
+++ b/nextroute/common/nsmallest_test.go
@@ -1,8 +1,9 @@
 package common_test
 
 import (
-	"github.com/nextmv-io/sdk/nextroute/common"
 	"testing"
+
+	"github.com/nextmv-io/sdk/nextroute/common"
 )
 
 type TestItem interface {

--- a/nextroute/common/speed.go
+++ b/nextroute/common/speed.go
@@ -23,22 +23,19 @@ func NewSpeed(
 	}
 }
 
-// NewKilometersPerHour returns a new speed unit of kilometers per hour.
-func NewKilometersPerHour() SpeedUnit {
-	return &speedUnitImpl{
-		distanceUnit: Kilometers,
-		duration:     time.Hour,
-	}
+// KilometersPerHour is a speed unit of kilometers per hour.
+var KilometersPerHour = &speedUnitImpl{
+	distanceUnit: Kilometers,
+	duration:     time.Hour,
 }
 
-// NewMilesPerHour returns a new speed unit of miles per hour.
-func NewMilesPerHour() SpeedUnit {
-	return &speedUnitImpl{
-		distanceUnit: Miles,
-		duration:     time.Hour,
-	}
+// MilesPerHour is a speed unit of miles per hour.
+var MilesPerHour = &speedUnitImpl{
+	distanceUnit: Miles,
+	duration:     time.Hour,
 }
 
+// MetersPerSecond is a speed unit of meters per second.
 var MetersPerSecond = &speedUnitImpl{
 	distanceUnit: Meters,
 	duration:     time.Second,

--- a/nextroute/common/statistics.go
+++ b/nextroute/common/statistics.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 )
 
+// Statistics describes statistics.
 type Statistics struct {
 	Count              float64
 	Sum                float64
@@ -22,6 +23,7 @@ type Statistics struct {
 	MidHinge           float64
 }
 
+// Report returns a string containing a report of the statistics.
 func (s Statistics) Report() string {
 	return fmt.Sprintf(
 		"Count                       : %d\n"+

--- a/nextroute/common/statistics_test.go
+++ b/nextroute/common/statistics_test.go
@@ -1,9 +1,10 @@
 package common_test
 
 import (
-	"github.com/nextmv-io/sdk/nextroute/common"
 	"math"
 	"testing"
+
+	"github.com/nextmv-io/sdk/nextroute/common"
 )
 
 func TestStatistics(t *testing.T) {
@@ -74,7 +75,11 @@ func TestStatistics(t *testing.T) {
 	}, statistics)
 }
 
-func testResult(t *testing.T, data []float64, expected, actual common.Statistics) {
+func testResult(
+	t *testing.T,
+	data []float64,
+	expected, actual common.Statistics,
+) {
 	if testNotEqual(expected.Count, actual.Count) {
 		t.Errorf(
 			"Count: expected %v, actual %v, data %v",
@@ -181,6 +186,7 @@ func testResult(t *testing.T, data []float64, expected, actual common.Statistics
 		)
 	}
 }
+
 func testEquals(expected, actual float64) bool {
 	return (math.IsNaN(expected) && math.IsNaN(actual)) ||
 		math.Abs(expected-actual) < 0.0000001

--- a/nextroute/model.go
+++ b/nextroute/model.go
@@ -28,7 +28,7 @@ func BuildModel(i schema.Input, m ModelOptions, opts ...Option) (Model, error) {
 
 // ModelOptions represents options for a model.
 type ModelOptions struct {
-	IgnoreCapacityConstraints      bool `json:"ignore_capacity_constraint" usage:"Ignore the capacity constraints"`
+	IgnoreCapacityConstraints      bool `json:"ignore_capacity_constraints" usage:"Ignore the capacity constraints"`
 	IgnoreServiceDurations         bool `json:"ignore_service_durations" usage:"Ignore the service durations of stops"`
 	IgnoreTravelDurationObjective  bool `json:"ignore_travel_duration_objective" usage:"Ignore the travel duration objective"`
 	IgnoreUnassignedStopsObjective bool `json:"ignore_unassigned_stops_objective" usage:"Ignore the unplanned objective"`

--- a/nextroute/model.go
+++ b/nextroute/model.go
@@ -28,7 +28,11 @@ func BuildModel(i schema.Input, m ModelOptions, opts ...Option) (Model, error) {
 
 // ModelOptions represents options for a model.
 type ModelOptions struct {
-	IgnoreUnplanned bool `json:"ignore_unplanned"  usage:"ignore unplanned penalties"`
+	IgnoreCapacityConstraints      bool `json:"ignore_capacity_constraint" usage:"Ignore the capacity constraints"`
+	IgnoreServiceDurations         bool `json:"ignore_service_durations" usage:"Ignore the service durations of stops"`
+	IgnoreTravelDurationObjective  bool `json:"ignore_travel_duration_objective" usage:"Ignore the travel duration objective"`
+	IgnoreUnassignedStopsObjective bool `json:"ignore_unassigned_stops_objective" usage:"Ignore the unplanned objective"`
+	IgnoreWindows                  bool `json:"ignore_windows" usage:"Ignore the stop windows"`
 }
 
 // Model defines routing problem.


### PR DESCRIPTION
Allows users to use program arguments (model options) to turn off certain options even though there is data in the input file.
For example the following model options are available:

ignore_capacity_constraint
ignore_service_durations
ignore_travel_duration_objective
ignore_unassigned_stops_objective
ignore_windows