### PR TITLE
Feature/eng 2799 cluster/inwardness option

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -24,6 +24,7 @@ func NewModel(
 
 // ModelOptions represents options for a model.
 type ModelOptions struct {
+	EnableClusterConstraint        bool `json:"enable_cluster_constraint" usage:"Enable the cluster constraint creating compact clusters of stops"`
 	IgnoreCapacityConstraints      bool `json:"ignore_capacity_constraints" usage:"Ignore the capacity constraints"`
 	IgnoreDistanceLimitConstraint  bool `json:"ignore_distance_limit_constraint" usage:"Ignore the distance limit constraint"`
 	IgnoreServiceDurations         bool `json:"ignore_service_durations" usage:"Ignore the service durations of stops"`


### PR DESCRIPTION
The inwardness constraint forces stops to be added to vehices whose centroid is closest to the stops added. Enabling this constraint creates compact, visually appealing, routes.