### PR TITLE
ENG-2709 Enable the max_duration constraint

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -24,14 +24,16 @@ func NewModel(
 
 // ModelOptions represents options for a model.
 type ModelOptions struct {
-	EnableClusterConstraint        bool `json:"enable_cluster_constraint" usage:"Enable the cluster constraint creating compact clusters of stops"`
-	IgnoreCapacityConstraint       bool `json:"ignore_capacity_constraint" usage:"Ignore the capacity constraint"`
-	IgnoreDistanceLimitConstraint  bool `json:"ignore_distance_limit_constraint" usage:"Ignore the distance limit constraint"`
-	IgnoreShiftConstraint          bool `json:"ignore_shift_constraint" usage:"Ignore the shift constraint"`
-	IgnoreWindowsConstraint        bool `json:"ignore_windows_constraint" usage:"Ignore the windows constraint"`
-	IgnoreServiceDurations         bool `json:"ignore_service_durations" usage:"Ignore the service durations of stops"`
-	IgnoreTravelDurationObjective  bool `json:"ignore_travel_duration_objective" usage:"Ignore the travel duration objective"`
-	IgnoreUnassignedStopsObjective bool `json:"ignore_unassigned_stops_objective" usage:"Ignore the unplanned objective"`
+	EnableClusterConstraint           bool `json:"enable_cluster_constraint" usage:"Enable the cluster constraint creating compact clusters of stops"`
+	IgnoreCapacityConstraint          bool `json:"ignore_capacity_constraint" usage:"Ignore the capacity constraint"`
+	IgnoreDistanceLimitConstraint     bool `json:"ignore_distance_limit_constraint" usage:"Ignore the distance limit constraint"`
+	IgnoreInitializationCostObjective bool `json:"ignore_initialization_cost_objective" usage:"Ignore the initialization cost objective"`
+	IgnoreMaximumDurationConstraint   bool `json:"ignore_maximum_duration_constraint" usage:"Ignore the maximum duration constraint"`
+	IgnoreServiceDurations            bool `json:"ignore_service_durations" usage:"Ignore the service durations of stops"`
+	IgnoreShiftConstraint             bool `json:"ignore_shift_constraint" usage:"Ignore the shift constraint"`
+	IgnoreTravelDurationObjective     bool `json:"ignore_travel_duration_objective" usage:"Ignore the travel duration objective"`
+	IgnoreUnassignedStopsObjective    bool `json:"ignore_unassigned_stops_objective" usage:"Ignore the unplanned objective"`
+	IgnoreWindowsConstraint           bool `json:"ignore_windows_constraint" usage:"Ignore the windows constraint"`
 }
 
 var (

--- a/nextroute/schema/output_basic.go
+++ b/nextroute/schema/output_basic.go
@@ -18,7 +18,6 @@ type VehicleOutput struct {
 	ID            string       `json:"id"`
 	Route         []StopOutput `json:"route"`
 	RouteDuration int          `json:"route_duration"`
-	RouteDistance int          `json:"route_distance"`
 }
 
 // StopOutput adds information to the input stop.


### PR DESCRIPTION
# Description

Adds a couple of fields to the `ModelOptions` and removes the `RouteDistance` from the basic output as we do not have the capability of calculating distance yet.