### PR TITLE
Durations to and from invalid stops will return 0

### DIFF
--- a/nextroute/model_vehicle_type.go
+++ b/nextroute/model_vehicle_type.go
@@ -8,7 +8,8 @@ type ModelVehicleType interface {
 	ModelData
 
 	// TemporalValues calculates the temporal values if the vehicle
-	// would depart at departure going from stop to stop.
+	// would depart at departure going from stop to stop. If from or to is
+	// invalid, the returned travelDuration will be 0.
 	TemporalValues(
 		departure float64,
 		from ModelStop,


### PR DESCRIPTION
# Description

Adding a comment that the duration from and to an invalid stop will be 0.