### PR TITLE
Remove extraneous quotes from platform name in usage string.

### DIFF
--- a/run/flagparser.go
+++ b/run/flagparser.go
@@ -45,7 +45,7 @@ func usage() {
 
 	fmt.Fprintf(
 		out,
-		"\"Nextmv Hybrid Optimization Platform\" %s\n",
+		"Nextmv Hybrid Optimization Platform %s\n",
 		sdk.VERSION,
 	)
 	fmt.Fprint(out, "Usage:\n")


### PR DESCRIPTION
This PR closes ENG-2948.

Before:
```
$ nextmv sdk run . -- -h
"Nextmv Hybrid Optimization Platform" v0.23.1
```

After:

```
$ nextmv sdk run . -- -h
Nextmv Hybrid Optimization Platform v0.23.1
```