### PR TITLE
Add error being returned in updating objective and constraint data

### DIFF
--- a/nextroute/model_constraint.go
+++ b/nextroute/model_constraint.go
@@ -31,7 +31,7 @@ type ConstraintDataUpdater interface {
 	// can use them to update the constraint data for the stop. The data
 	// returned can be used by the estimate function and can be retrieved by the
 	// SolutionStop.ConstraintValue function.
-	UpdateConstraintData(s SolutionStop) Copier
+	UpdateConstraintData(s SolutionStop) (Copier, error)
 }
 
 // RegisteredModelExpressions is the interface that exposes the expressions

--- a/nextroute/model_objective.go
+++ b/nextroute/model_objective.go
@@ -8,7 +8,7 @@ type ObjectiveDataUpdater interface {
 	// can use them to update the objective data for the stop. The data
 	// returned can be used by the estimate function and can be retrieved by the
 	// SolutionStop.ObjectiveValue function.
-	UpdateObjectiveData(s SolutionStop) Copier
+	UpdateObjectiveData(s SolutionStop) (Copier, error)
 }
 
 // ModelObjective is an objective function that can be used to optimize a


### PR DESCRIPTION
# Description

The current signature of these two methods forces users to panic instead of returning an error. This PR adds an error being returned.