### PR TITLE
Fix comment style and rename RunStart

### DIFF
--- a/run/decoder.go
+++ b/run/decoder.go
@@ -44,7 +44,7 @@ func (g *genericDecoder[Input]) Decoder(
 	ioReader, ok := reader.(io.Reader)
 	if !ok {
 		err = errors.New(
-			"Decoder is not compatible with configured IOProducer",
+			"decoder is not compatible with configured IOProducer",
 		)
 		return input, err
 	}

--- a/run/encoder.go
+++ b/run/encoder.go
@@ -93,22 +93,14 @@ func (g *genericEncoder[Solution, Options]) Encode(
 		for solution := range solutions {
 			m.Solutions = append(m.Solutions, solution)
 		}
-		if err = g.encoder.Encode(ioWriter, m); err != nil {
-			return err
-		}
-
-		return nil
+		return g.encoder.Encode(ioWriter, m)
 	}
 
 	m := []Solution{}
 	for solution := range solutions {
 		m = append(m, solution)
 	}
-	if err = g.encoder.Encode(ioWriter, m); err != nil {
-		return err
-	}
-
-	return nil
+	return g.encoder.Encode(ioWriter, m)
 }
 
 func (g *genericEncoder[Solution, Options]) ContentType() string {

--- a/run/encoder.go
+++ b/run/encoder.go
@@ -56,7 +56,7 @@ func (g *genericEncoder[Solution, Options]) Encode(
 
 	ioWriter, ok := writer.(io.Writer)
 	if !ok {
-		err = errors.New("Encoder is not compatible with configured IOProducer")
+		err = errors.New("encoder is not compatible with configured IOProducer")
 		return err
 	}
 

--- a/run/generic_runner.go
+++ b/run/generic_runner.go
@@ -12,7 +12,7 @@ import (
 
 type start string
 
-// RunStart is the key for the start time of the run.
+// Start is the key for the start time of the run.
 const Start start = "start"
 
 // GenericRunner creates a new runner from the given components.

--- a/run/generic_runner.go
+++ b/run/generic_runner.go
@@ -10,10 +10,10 @@ import (
 	"time"
 )
 
-type runStart string
+type start string
 
 // RunStart is the key for the start time of the run.
-const RunStart runStart = "start"
+const Start start = "start"
 
 // GenericRunner creates a new runner from the given components.
 func GenericRunner[RunnerConfig, Input, Option, Solution any](
@@ -111,7 +111,7 @@ func (r *genericRunner[RunnerConfig, Input, Option, Solution]) Run(
 	ctx context.Context,
 ) (retErr error) {
 	start := time.Now()
-	ctx = context.WithValue(ctx, RunStart, start)
+	ctx = context.WithValue(ctx, Start, start)
 	// handle CPU profile
 	deferFuncCPU, retErr := r.handleCPUProfile(r.runnerConfig)
 	if retErr != nil {

--- a/run/http_runner.go
+++ b/run/http_runner.go
@@ -169,7 +169,7 @@ func (h *httpRunner[Input, Option, Solution]) setRunnerOption(
 }
 
 func (h *httpRunner[Input, Option, Solution]) Run(
-	context context.Context,
+	_ context.Context,
 ) error {
 	httpRunnerConfig := h.Runner.RunnerConfig()
 	if httpRunnerConfig.Runner.HTTP.Certificate != "" ||


### PR DESCRIPTION
# Changes

- Some renaming of symbols to prevent "stuttering"
- Make comments start with lower case letters and not end in punctuation