### PR TITLE
Changes output struct order for better readability

### DIFF
--- a/run/schema/schema.go
+++ b/run/schema/schema.go
@@ -13,10 +13,10 @@ type Version struct {
 
 // Output adds Output information by wrapping the solutions.
 type Output struct {
-	Statistics statistics.Statistics `json:"statistics,omitempty"`
-	Options    any                   `json:"options,omitempty"`
 	Version    Version               `json:"version,omitempty"`
+	Options    any                   `json:"options,omitempty"`
 	Solutions  []any                 `json:"solutions,omitempty"`
+	Statistics statistics.Statistics `json:"statistics,omitempty"`
 }
 
 // NewOutput creates a new Output.

--- a/run/schema/schema.go
+++ b/run/schema/schema.go
@@ -13,10 +13,10 @@ type Version struct {
 
 // Output adds Output information by wrapping the solutions.
 type Output struct {
-	Version    Version               `json:"version,omitempty"`
-	Options    any                   `json:"options,omitempty"`
-	Solutions  []any                 `json:"solutions,omitempty"`
-	Statistics statistics.Statistics `json:"statistics,omitempty"`
+	Version    Version                `json:"version,omitempty"`
+	Options    any                    `json:"options,omitempty"`
+	Solutions  []any                  `json:"solutions,omitempty"`
+	Statistics *statistics.Statistics `json:"statistics,omitempty"`
 }
 
 // NewOutput creates a new Output.

--- a/run/schema/schema.go
+++ b/run/schema/schema.go
@@ -20,9 +20,14 @@ type Output struct {
 }
 
 // NewOutput creates a new Output.
-func NewOutput(options any, solutions ...any) Output {
+func NewOutput[Solution any](options any, solutions ...Solution) Output {
+	// convert solutions to any
+	solutionsAny := make([]any, len(solutions))
+	for i, solution := range solutions {
+		solutionsAny[i] = solution
+	}
 	return Output{
-		Solutions: solutions,
+		Solutions: solutionsAny,
 		Options:   options,
 		Version: Version{
 			Sdk: sdk.VERSION,


### PR DESCRIPTION
# Description

Changes the order of the fields in the output struct for improved readability (JSON marshaling uses the struct field order).
