### PR TITLE
Return dates in the timezone of the user

### DIFF
--- a/nextroute/solution_format.go
+++ b/nextroute/solution_format.go
@@ -144,9 +144,10 @@ func setTimes(
 	stopOutput schema.PlannedStopOutput,
 	hasUserDefinedStartTime bool,
 ) schema.PlannedStopOutput {
-	arrival := solutionStop.Arrival()
-	departure := solutionStop.End()
-	service := solutionStop.Start()
+	timezoneLocation := solutionStop.Vehicle().Start().Location()
+	arrival := solutionStop.Arrival().In(timezoneLocation)
+	departure := solutionStop.End().In(timezoneLocation)
+	service := solutionStop.Start().In(timezoneLocation)
 	if hasUserDefinedStartTime {
 		stopOutput.ArrivalTime = &arrival
 		stopOutput.EndTime = &departure
@@ -163,7 +164,8 @@ func setTimes(
 	if !ok || inputStop.TargetArrivalTime == nil {
 		return stopOutput
 	}
-	stopOutput.TargetArrivalTime = inputStop.TargetArrivalTime
+	targetArrivalTime := inputStop.TargetArrivalTime.In(timezoneLocation)
+	stopOutput.TargetArrivalTime = &targetArrivalTime
 
 	if inputStop.EarlyArrivalTimePenalty != nil {
 		earliness := int(math.Max(inputStop.TargetArrivalTime.Sub(arrival).Seconds(), 0.0))

--- a/nextroute/solution_format.go
+++ b/nextroute/solution_format.go
@@ -144,7 +144,9 @@ func setTimes(
 	stopOutput schema.PlannedStopOutput,
 	hasUserDefinedStartTime bool,
 ) schema.PlannedStopOutput {
-	timezoneLocation := solutionStop.Vehicle().Start().Location()
+	// we need to access the timezone via the vehicle of the model
+	timezoneLocation := solutionStop.ModelStop().Model().
+		Vehicle(solutionStop.VehicleIndex()).Start().Location()
 	arrival := solutionStop.Arrival().In(timezoneLocation)
 	departure := solutionStop.End().In(timezoneLocation)
 	service := solutionStop.Start().In(timezoneLocation)


### PR DESCRIPTION
# Description

Users of `nextroute` provide `times` in their own timezones. This PR ensures that we output them in the same timezone as they came in.