### PR TITLE
Add RangeMap to allow deterministic ranging over maps

### DIFF
--- a/alns/solve_solution.go
+++ b/alns/solve_solution.go
@@ -52,4 +52,5 @@ type Progressioner interface {
 type ProgressionEntry struct {
 	ElapsedSeconds float64 `json:"elapsed_seconds"`
 	Value          float64 `json:"value"`
+	Iterations     int     `json:"iterations"`
 }

--- a/nextroute/solution_format.go
+++ b/nextroute/solution_format.go
@@ -93,10 +93,15 @@ func Format(
 	}
 
 	seriesData := make([]statistics.DataPoint, 0)
+	iterationsSeriesData := make([]statistics.DataPoint, 0)
 	for _, progression := range progressionValues {
 		seriesData = append(seriesData, statistics.DataPoint{
 			X: statistics.Float64(progression.ElapsedSeconds),
 			Y: statistics.Float64(progression.Value),
+		})
+		iterationsSeriesData = append(iterationsSeriesData, statistics.DataPoint{
+			X: statistics.Float64(progression.ElapsedSeconds),
+			Y: statistics.Float64(progression.Iterations),
 		})
 	}
 	lastProgressionElement := progressionValues[len(progressionValues)-1]
@@ -107,6 +112,10 @@ func Format(
 			DataPoints: seriesData,
 		},
 	}
+	output.Statistics.SeriesData.Custom = append(output.Statistics.SeriesData.Custom, statistics.Series{
+		Name:       "iterations",
+		DataPoints: iterationsSeriesData,
+	})
 	output.Statistics.Result = &statistics.Result{
 		Duration: &lastProgressionElement.ElapsedSeconds,
 		Value:    &lastProgressionValue,

--- a/nextroute/solver_parallel.go
+++ b/nextroute/solver_parallel.go
@@ -9,6 +9,7 @@ import (
 
 // ParallelSolveOptions are the options for the parallel solver.
 type ParallelSolveOptions struct {
+	Iterations           int           `json:"iterations"  usage:"maximum number of iterations, -1 assumes no limit; iterations are counted after start solutions are generated" default:"-1"`
 	Duration             time.Duration `json:"duration" usage:"maximum duration of the solver" default:"30s"`
 	ParallelRuns         int           `json:"parallel_runs" usage:"maximum number of parallel runs, -1 results in using all available resources" default:"100"`
 	StartSolutions       int           `json:"start_solutions" usage:"number of solutions to generate on top of those passed in; one solution generated with sweep algorithm, the rest generated randomly" default:"-1"`


### PR DESCRIPTION
# Description

Ranging over maps in Go deliberately happens in random order. This is ok in some cases, but in others it is not. In our case, whenever we have a break criteria in the loop ranging over a map, this will randomly influence the runtime. This PR introduces a helper function that can be used to safely range over maps.