### PR TITLE
Allow the user to define a start level for each resource used in the capacity constraint

### DIFF
--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -26,6 +26,7 @@ type Defaults struct {
 // VehicleDefaults contains default values for vehicles.
 type VehicleDefaults struct {
 	Capacity                any        `json:"capacity,omitempty"`
+	StartLevel              any        `json:"start_level,omitempty"`
 	StartLocation           *Location  `json:"start_location,omitempty"`
 	EndLocation             *Location  `json:"end_location,omitempty"`
 	Speed                   *float64   `json:"speed,omitempty"`
@@ -54,6 +55,7 @@ type StopDefaults struct {
 // Vehicle represents a vehicle.
 type Vehicle struct {
 	Capacity                any        `json:"capacity,omitempty"`
+	StartLevel              any        `json:"start_level,omitempty"`
 	StartLocation           *Location  `json:"start_location,omitempty"`
 	EndLocation             *Location  `json:"end_location,omitempty"`
 	Speed                   *float64   `json:"speed,omitempty"`


### PR DESCRIPTION
# Description

Allow the user to define a start level for each resource used in the capacity constraint.

## Changes

* An optional field start_level has been added to Input.Vehicle schema
* An optional field start_level has been added to Input.VehicleDefaults schema

## Functionality

The level of each resource defined in the input schema has a default start level of zero.  The default start level can be overruled using the start_level on Input.Vehicle and Input.VehicleDefaults.