### PR TITLE
Change `initialization_cost` to `activation_penalty`

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -54,12 +54,12 @@ type Options struct {
 		} `json:"enable"`
 	} `json:"constraints"`
 	Objectives struct {
-		EarlyArrival       float64 `json:"early_arrival" usage:"factor to weigh the early arrival objective" default:"1.0"`
-		LateArrival        float64 `json:"late_arrival" usage:"factor to weigh the late arrival objective" default:"1.0"`
-		InitializationCost float64 `json:"initialization_cost" usage:"factor to weigh the initialization cost objective" default:"1.0"`
-		TravelDuration     float64 `json:"travel_duration" usage:"factor to weigh the travel duration objective" default:"1.0"`
-		Unplanned          float64 `json:"unplanned" usage:"factor to weigh the unplanned objective" default:"1.0"`
-		Cluster            float64 `json:"cluster" usage:"factor to weigh the cluster objective" default:"0.0"`
+		EarlyArrivalPenalty      float64 `json:"early_arrival_penalty" usage:"factor to weigh the early arrival objective" default:"1.0"`
+		LateArrivalPenalty       float64 `json:"late_arrival_penalty" usage:"factor to weigh the late arrival objective" default:"1.0"`
+		VehicleActivationPenalty float64 `json:"vehicle_activation_penalty" usage:"factor to weigh the vehicle activation objective" default:"1.0"`
+		TravelDuration           float64 `json:"travel_duration" usage:"factor to weigh the travel duration objective" default:"1.0"`
+		UnplannedPenalty         float64 `json:"unplanned_penalty" usage:"factor to weigh the unplanned objective" default:"1.0"`
+		Cluster                  float64 `json:"cluster" usage:"factor to weigh the cluster objective" default:"0.0"`
 	} `json:"objectives"`
 	Properties struct {
 		Disable struct {

--- a/nextroute/model_objective_vehicles.go
+++ b/nextroute/model_objective_vehicles.go
@@ -18,5 +18,5 @@ func NewVehiclesObjective(expression VehicleTypeExpression) VehiclesObjective {
 type VehiclesObjective interface {
 	ModelObjective
 	// InitializationCost returns the initialization cost expression.
-	InitializationCost() VehicleTypeExpression
+	ActivationPenalty() VehicleTypeExpression
 }

--- a/nextroute/model_objective_vehicles.go
+++ b/nextroute/model_objective_vehicles.go
@@ -17,6 +17,6 @@ func NewVehiclesObjective(expression VehicleTypeExpression) VehiclesObjective {
 // and last visit).
 type VehiclesObjective interface {
 	ModelObjective
-	// InitializationCost returns the initialization cost expression.
+	// ActivationPenalty returns the activation penalty expression.
 	ActivationPenalty() VehicleTypeExpression
 }

--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -67,7 +67,7 @@ type Vehicle struct {
 	MaxDistance             *int           `json:"max_distance,omitempty"`
 	MaxDuration             *int           `json:"max_duration,omitempty"`
 	MaxWait                 *int           `json:"max_wait,omitempty"`
-	InitializationCost      *int           `json:"initialization_cost,omitempty"`
+	ActivationPenalty       *int           `json:"activation_penalty,omitempty"`
 	CustomData              any            `json:"custom_data,omitempty"`
 	InitialStops            *[]InitialStop `json:"initial_stops,omitempty"`
 }


### PR DESCRIPTION
# Description

I believe this is the last part of the input that needed to be updated to be consistent. All other objectives that are penalties are named `penalty` so this PR does the same for the former initialization cost.