### PR TITLE
Correct handling of triangular inequality for initial stops

### DIFF
--- a/nextroute/model_constraint.go
+++ b/nextroute/model_constraint.go
@@ -42,6 +42,16 @@ type RegisteredModelExpressions interface {
 	ModelExpressions() ModelExpressions
 }
 
+// ConstraintTemporal is the interface that is implemented by constraints that
+// are temporal. This interface is used to determine if the constraint is
+// using temporal expressions, specifically travel durations. Temporal
+// constraints require special handling when adding initial stops to a
+// new solution because of the triangular inequality.
+type ConstraintTemporal interface {
+	// IsTemporal returns true if the constraint is temporal.
+	IsTemporal() bool
+}
+
 // SolutionStopViolationCheck is the interface that will be invoked on every
 // update of a planned solution stop. The method DoesStopHaveViolations will be
 // called to check if the stop violates the constraint. If the method returns

--- a/nextroute/model_expression_time_dependent.go
+++ b/nextroute/model_expression_time_dependent.go
@@ -55,11 +55,23 @@ type TimeDependentDurationExpression interface {
 	// for all time intervals.
 	IsDependentOnTime() bool
 
+	// SatisfiesTriangleInequality returns true if the expression satisfies
+	// the triangle inequality. The triangular inequality states that for any
+	// three points A, B, and C, the distance from A to C cannot be greater
+	// than the sum of the distances from A to B and from B to C.
+	SatisfiesTriangleInequality() bool
+
 	// SetExpression sets the expression for the given time interval
 	// [start, end). If the interval overlaps with an existing interval,
 	// the existing interval is replaced. Both start and end must be on the
 	// minute boundary. Expression is not allowed to contain negative values.
 	SetExpression(start, end time.Time, expression DurationExpression) error
+
+	// SetSatisfiesTriangleInequality sets whether the expression satisfies
+	// the triangle inequality. The triangular inequality states that for any
+	// three points A, B, and C, the distance from A to C cannot be greater
+	// than the sum of the distances from A to B and from B to C.
+	SetSatisfiesTriangleInequality(satisfies bool)
 
 	// Expressions returns all expressions defined to be valid in a time
 	// interval. The returned slice is a defensive copy of the internal slice,


### PR DESCRIPTION
To deal with the condition of triangular inequality the following has been introduced:

* `TimeDependentDurationExpression::SatisfiesTriangleInequality() bool`
* `TimeDependentDurationExpression::SetSatisfiesTriangleInequality(satisfies bool)`

This allows the user to specify if the invoking expression complies with the triangular inequality. The default is false which triggers some additional checking when unplanning units. If the user specifies that the expression complies with the triangular inequality by invoking `SetSatisfiesTriangleInequality(true)` the solver can leverage this information to be more efficient.

Also the following interface has been introduced `ConstraintTemporal`. This interface can be implemented on a custom constraint to tell nextroute that the constraint is using temporal expressions (travel duration). This information is used when initial stops are being added to a solution.