### PR TITLE
Uses point tuples instead of polyline for osrm table

### DIFF
--- a/route/osrm/client.go
+++ b/route/osrm/client.go
@@ -268,7 +268,7 @@ func (c *client) tableRequests( //nolint:gocyclo
 	convertedPoints := make([][]float64, len(points))
 	for i, point := range handleUnroutablePoints(points) {
 		convertedPoints[i] = []float64{
-			point[1], point[0],
+			point[0], point[1],
 		}
 	}
 	pointChunks := chunkBy(convertedPoints, c.maxTableSize)
@@ -278,8 +278,16 @@ func (c *client) tableRequests( //nolint:gocyclo
 			resultingChunk := make([][]float64, len(pointChunk1)+len(pointChunk2))
 			copy(resultingChunk, pointChunk1)
 			copy(resultingChunk[len(pointChunk1):], pointChunk2)
-			pointsParameter := polyline.EncodeCoords(resultingChunk)
-			path, err := getPath(TableEndpoint, "polyline("+string(pointsParameter)+")")
+
+			// Create points string and assemble path.
+			sb := strings.Builder{}
+			for i, point := range resultingChunk {
+				sb.WriteString(fmt.Sprintf("%f,%f", point[0], point[1]))
+				if i != len(resultingChunk)-1 {
+					sb.WriteString(";")
+				}
+			}
+			path, err := getPath(TableEndpoint, sb.String())
 			if err != nil {
 				return nil, err
 			}

--- a/route/osrm/client_test.go
+++ b/route/osrm/client_test.go
@@ -51,13 +51,15 @@ func newTestServer(t *testing.T, endpoint osrm.Endpoint) *testServer {
 		responseOk = string(resp)
 	}
 	ts.s = httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			ts.reqCount++
-			_, err := io.WriteString(w, responseOk)
-			if err != nil {
-				t.Errorf("could not write resp: %v", err)
-			}
-		}),
+		http.AllowQuerySemicolons(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				ts.reqCount++
+				_, err := io.WriteString(w, responseOk)
+				if err != nil {
+					t.Errorf("could not write resp: %v", err)
+				}
+			}),
+		),
 	)
 	return ts
 }

--- a/route/osrm/go.mod
+++ b/route/osrm/go.mod
@@ -8,6 +8,5 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/nextmv-io/sdk v0.24.2
+	github.com/twpayne/go-polyline v1.1.1
 )
-
-require github.com/twpayne/go-polyline v1.1.1

--- a/route/osrm/matrix_test.go
+++ b/route/osrm/matrix_test.go
@@ -58,14 +58,16 @@ func newMockOSRM(
 	durations [][]float64,
 ) *httptest.Server {
 	return httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"code":      "Ok",
-				"distances": distances,
-				"durations": durations,
-				"message":   "Everything worked",
-			})
-		}),
+		http.AllowQuerySemicolons(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"code":      "Ok",
+					"distances": distances,
+					"durations": durations,
+					"message":   "Everything worked",
+				})
+			}),
+		),
 	)
 }
 


### PR DESCRIPTION
# Description

There are some edge cases in which polyline encoding of points screws up the matrices returned by OSRM. In order to avoid these unpredictable edge cases we decided to revert to using explicit point tuples as the request params.

## Changes

- Uses point tuples instead of polyline in osrm table request
- Fixes a warning in osrm tests