### PR TITLE
feature/eng-2988-cloud-routing-app-parity-support-duration-groups

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -64,6 +64,7 @@ type Options struct {
 	Properties struct {
 		Disable struct {
 			Durations       bool `json:"durations" usage:"ignore the durations of stops"`
+			GroupDurations  bool `json:"group_durations" usage:"ignore the group durations of stops"`
 			InitialSolution bool `json:"initial_solution" usage:"ignore the initial solution"`
 		} `json:"disable"`
 	} `json:"properties"`

--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -64,7 +64,7 @@ type Options struct {
 	Properties struct {
 		Disable struct {
 			Durations       bool `json:"durations" usage:"ignore the durations of stops"`
-			GroupDurations  bool `json:"group_durations" usage:"ignore the group durations of stops"`
+			DurationGroups  bool `json:"duration_groups" usage:"ignore the durations groups of stops"`
 			InitialSolution bool `json:"initial_solution" usage:"ignore the initial solution"`
 		} `json:"disable"`
 	} `json:"properties"`

--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -7,14 +7,15 @@ import (
 
 // Input is the default input schema for nextroute.
 type Input struct {
-	Options        any          `json:"options,omitempty"`
-	Defaults       *Defaults    `json:"defaults,omitempty"`
-	StopGroups     *[][]string  `json:"stop_groups,omitempty"`
-	DurationMatrix *[][]float64 `json:"duration_matrix,omitempty"`
-	DistanceMatrix *[][]float64 `json:"distance_matrix,omitempty"`
-	Vehicles       []Vehicle    `json:"vehicles,omitempty"`
-	Stops          []Stop       `json:"stops,omitempty"`
-	CustomData     any          `json:"custom_data,omitempty"`
+	Options        any              `json:"options,omitempty"`
+	Defaults       *Defaults        `json:"defaults,omitempty"`
+	StopGroups     *[][]string      `json:"stop_groups,omitempty"`
+	DurationMatrix *[][]float64     `json:"duration_matrix,omitempty"`
+	DistanceMatrix *[][]float64     `json:"distance_matrix,omitempty"`
+	Vehicles       []Vehicle        `json:"vehicles,omitempty"`
+	Stops          []Stop           `json:"stops,omitempty"`
+	DurationGroups *[]DurationGroup `json:"duration_groups,omitempty"`
+	CustomData     any              `json:"custom_data,omitempty"`
 }
 
 // Defaults contains default values for vehicles and stops.
@@ -100,4 +101,11 @@ type Stop struct {
 type Location struct {
 	Lon float64 `json:"lon"`
 	Lat float64 `json:"lat"`
+}
+
+// DurationGroup represents a group of stops that get additional process time
+// (duration) whenever a stop of the group is approached for the first time.
+type DurationGroup struct {
+	Group    []string `json:"group,omitempty"`
+	Duration int      `json:"duration,omitempty"`
 }

--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -103,8 +103,8 @@ type Location struct {
 	Lat float64 `json:"lat"`
 }
 
-// DurationGroup represents a group of stops that get additional process time
-// (duration) whenever a stop of the group is approached for the first time.
+// DurationGroup represents a group of stops that get additional duration
+// whenever a stop of the group is approached for the first time.
 type DurationGroup struct {
 	Group    []string `json:"group,omitempty"`
 	Duration int      `json:"duration,omitempty"`

--- a/route/routingkit/example_measure_test.go
+++ b/route/routingkit/example_measure_test.go
@@ -169,5 +169,5 @@ func Example_customProfile() {
 	)
 	fmt.Println(int(cost))
 	// Output:
-	// 1229
+	// 1194
 }

--- a/route/routingkit/measure_test.go
+++ b/route/routingkit/measure_test.go
@@ -20,7 +20,7 @@ func TestFallback(t *testing.T) {
 		{7.336650, 52.145020},
 	}
 	dests := []route.Point{
-		{7.32486, 52.14280},
+		{1.32486, 52.14280},
 		{7.31893, 52.15924},
 	}
 	expected := [][]float64{
@@ -60,9 +60,9 @@ func TestMatrix(t *testing.T) {
 		{7.35630, 52.14031},
 	}
 	expected := [][]float64{
-		{2346, 2466},
-		{2855, 2954},
-		{2186, 1962},
+		{2346, 2465},
+		{2855, 2951},
+		{2186, 1961},
 		{2834, 2423},
 	}
 
@@ -246,7 +246,7 @@ func TestByIndexLoader(t *testing.T) {
 			expectedErr: false,
 			from:        0,
 			to:          0,
-			expected:    841,
+			expected:    1200,
 		},
 		// routingkitDurationMatrix
 		{
@@ -270,7 +270,7 @@ func TestByIndexLoader(t *testing.T) {
 			expectedErr: false,
 			from:        0,
 			to:          0,
-			expected:    841,
+			expected:    246,
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
# Description

This PR adds duration groups to nextroute.
