### PR TITLE
Rename ArrivalTimeWindows to StartTimeWindows

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -47,7 +47,7 @@ type Options struct {
 			Precedence         bool `json:"precedence" usage:"ignore the precedence (pickups & deliveries) constraint"`
 			VehicleStartTime   bool `json:"vehicle_start_time" usage:"ignore the vehicle start time constraint"`
 			VehicleEndTime     bool `json:"vehicle_end_time" usage:"ignore the vehicle end time constraint"`
-			ArrivalTimeWindows bool `json:"arrival_time_windows" usage:"ignore the arrival time windows constraint"`
+			StartTimeWindows   bool `json:"start_time_windows" usage:"ignore the start time windows constraint"`
 		} `json:"disable"`
 		Enable struct {
 			Cluster bool `json:"cluster" usage:"enable the cluster constraint"`


### PR DESCRIPTION
# Description

We name the windows during which a vehicle can serve a customer `StartTimeWindows`. We missed the naming in the options which allows to disable the constraint. This PR aligns the naming.