### PR TITLE
Add vehicles duration objective

### DIFF
--- a/nextroute/engine.go
+++ b/nextroute/engine.go
@@ -144,6 +144,7 @@ var (
 	newVehiclesObjective   func(
 		VehicleTypeExpression,
 	) VehiclesObjective
+	newVehiclesDurationObjective  func() VehiclesDurationObjective
 	newVehicleTypeValueExpression func(
 		string,
 		float64,

--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -57,7 +57,8 @@ type Options struct {
 		EarlyArrivalPenalty      float64 `json:"early_arrival_penalty" usage:"factor to weigh the early arrival objective" default:"1.0"`
 		LateArrivalPenalty       float64 `json:"late_arrival_penalty" usage:"factor to weigh the late arrival objective" default:"1.0"`
 		VehicleActivationPenalty float64 `json:"vehicle_activation_penalty" usage:"factor to weigh the vehicle activation objective" default:"1.0"`
-		TravelDuration           float64 `json:"travel_duration" usage:"factor to weigh the travel duration objective" default:"1.0"`
+		TravelDuration           float64 `json:"travel_duration" usage:"factor to weigh the travel duration objective" default:"0.0"`
+		VehiclesDuration         float64 `json:"vehicles_duration" usage:"factor to weigh the vehicles duration objective" default:"1.0"`
 		UnplannedPenalty         float64 `json:"unplanned_penalty" usage:"factor to weigh the unplanned objective" default:"1.0"`
 		Cluster                  float64 `json:"cluster" usage:"factor to weigh the cluster objective" default:"0.0"`
 	} `json:"objectives"`

--- a/nextroute/model_objective_vehicleduration.go
+++ b/nextroute/model_objective_vehicleduration.go
@@ -2,14 +2,14 @@ package nextroute
 
 import "github.com/nextmv-io/sdk/connect"
 
-// NewVehicleDurationObjective returns a new VehicleDurationObjective that
+// NewVehiclesDurationObjective returns a new VehiclesDurationObjective that
 // uses the vehicle duration as an objective.
 func NewVehiclesDurationObjective() VehiclesDurationObjective {
 	connect.Connect(con, &newVehiclesDurationObjective)
 	return newVehiclesDurationObjective()
 }
 
-// VehicleDurationObjective is an objective that uses the vehicle duration as an
+// VehiclesDurationObjective is an objective that uses the vehicle duration as an
 // objective.
 type VehiclesDurationObjective interface {
 	ModelObjective

--- a/nextroute/model_objective_vehicleduration.go
+++ b/nextroute/model_objective_vehicleduration.go
@@ -1,0 +1,16 @@
+package nextroute
+
+import "github.com/nextmv-io/sdk/connect"
+
+// NewVehicleDurationObjective returns a new VehicleDurationObjective that
+// uses the vehicle duration as an objective.
+func NewVehiclesDurationObjective() VehiclesDurationObjective {
+	connect.Connect(con, &newVehiclesDurationObjective)
+	return newVehiclesDurationObjective()
+}
+
+// VehicleDurationObjective is an objective that uses the vehicle duration as an
+// objective.
+type VehiclesDurationObjective interface {
+	ModelObjective
+}

--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -8,14 +8,14 @@ import (
 // Input is the default input schema for nextroute.
 type Input struct {
 	Options        any              `json:"options,omitempty"`
+	CustomData     any              `json:"custom_data,omitempty"`
 	Defaults       *Defaults        `json:"defaults,omitempty"`
 	StopGroups     *[][]string      `json:"stop_groups,omitempty"`
 	DurationMatrix *[][]float64     `json:"duration_matrix,omitempty"`
 	DistanceMatrix *[][]float64     `json:"distance_matrix,omitempty"`
+	DurationGroups *[]DurationGroup `json:"duration_groups,omitempty"`
 	Vehicles       []Vehicle        `json:"vehicles,omitempty"`
 	Stops          []Stop           `json:"stops,omitempty"`
-	DurationGroups *[]DurationGroup `json:"duration_groups,omitempty"`
-	CustomData     any              `json:"custom_data,omitempty"`
 }
 
 // Defaults contains default values for vehicles and stops.
@@ -38,6 +38,7 @@ type VehicleDefaults struct {
 	MaxDuration             *int       `json:"max_duration,omitempty"`
 	MaxWait                 *int       `json:"max_wait,omitempty"`
 	CompatibilityAttributes *[]string  `json:"compatibility_attributes,omitempty"`
+	ActivationPenalty       *int       `json:"activation_penalty,omitempty"`
 }
 
 // StopDefaults contains default values for stops.
@@ -57,27 +58,27 @@ type StopDefaults struct {
 type Vehicle struct {
 	Capacity                any            `json:"capacity,omitempty"`
 	StartLevel              any            `json:"start_level,omitempty"`
-	StartLocation           *Location      `json:"start_location,omitempty"`
-	EndLocation             *Location      `json:"end_location,omitempty"`
-	Speed                   *float64       `json:"speed,omitempty"`
-	ID                      string         `json:"id,omitempty"`
+	CustomData              any            `json:"custom_data,omitempty"`
+	CompatibilityAttributes *[]string      `json:"compatibility_attributes,omitempty"`
+	MaxDistance             *int           `json:"max_distance,omitempty"`
+	StopDurationMultiplier  *float64       `json:"stop_duration_multiplier,omitempty"`
 	StartTime               *time.Time     `json:"start_time,omitempty"`
 	EndTime                 *time.Time     `json:"end_time,omitempty"`
-	CompatibilityAttributes *[]string      `json:"compatibility_attributes,omitempty"`
+	EndLocation             *Location      `json:"end_location,omitempty"`
 	MaxStops                *int           `json:"max_stops,omitempty"`
-	MaxDistance             *int           `json:"max_distance,omitempty"`
+	Speed                   *float64       `json:"speed,omitempty"`
 	MaxDuration             *int           `json:"max_duration,omitempty"`
 	MaxWait                 *int           `json:"max_wait,omitempty"`
 	ActivationPenalty       *int           `json:"activation_penalty,omitempty"`
-	CustomData              any            `json:"custom_data,omitempty"`
+	StartLocation           *Location      `json:"start_location,omitempty"`
 	InitialStops            *[]InitialStop `json:"initial_stops,omitempty"`
-	StopDurationMultiplier  *float64       `json:"stop_duration_multiplier,omitempty"`
+	ID                      string         `json:"id,omitempty"`
 }
 
 // InitialStop represents an initial stop.
 type InitialStop struct {
-	ID    string `json:"id"`
 	Fixed *bool  `json:"fixed,omitempty"`
+	ID    string `json:"id"`
 }
 
 // Stop represents a stop.
@@ -85,17 +86,17 @@ type Stop struct {
 	Precedes                any          `json:"precedes,omitempty"`
 	Quantity                any          `json:"quantity,omitempty"`
 	Succeeds                any          `json:"succeeds,omitempty"`
-	TargetArrivalTime       *time.Time   `json:"target_arrival_time,omitempty"`
-	StartTimeWindow         *[]time.Time `json:"start_time_window,omitempty"`
-	MaxWait                 *int         `json:"max_wait,omitempty"`
+	CustomData              any          `json:"custom_data,omitempty"`
 	Duration                *int         `json:"duration,omitempty"`
+	MaxWait                 *int         `json:"max_wait,omitempty"`
+	StartTimeWindow         *[]time.Time `json:"start_time_window,omitempty"`
 	UnplannedPenalty        *int         `json:"unplanned_penalty,omitempty"`
 	EarlyArrivalTimePenalty *float64     `json:"early_arrival_time_penalty,omitempty"`
 	LateArrivalTimePenalty  *float64     `json:"late_arrival_time_penalty,omitempty"`
 	CompatibilityAttributes *[]string    `json:"compatibility_attributes,omitempty"`
+	TargetArrivalTime       *time.Time   `json:"target_arrival_time,omitempty"`
 	ID                      string       `json:"id,omitempty"`
 	Location                Location     `json:"location,omitempty"`
-	CustomData              any          `json:"custom_data,omitempty"`
 }
 
 // Location represents a geographical location.


### PR DESCRIPTION
# Description

Up to this PR the default objective optimizes the `TravelDurationObjective` which is the time the vehicle moves. This PR introduces a new objective `VehiclesDurationObjective` which also reflects service durations and waiting times. It is the new default objective for nextroute.