### PR TITLE
Prevent result encoding on error

### DIFF
--- a/run/encoder.go
+++ b/run/encoder.go
@@ -64,8 +64,13 @@ func (g *genericEncoder[Solution, Options]) Encode(
 
 		if solutionFlag == Last {
 			var last Solution
+			lastIsSet := false
 			for solution := range solutions {
 				last = solution
+				lastIsSet = true
+			}
+			if !lastIsSet {
+				return nil
 			}
 			tempSolutions := make(chan Solution, 1)
 			tempSolutions <- last


### PR DESCRIPTION
# Description

When the runner returns an error, the result (usually `nil`) should not get encoded and written to output.