### PR TITLE
Adds IsFixed to PlanUnit

### DIFF
--- a/nextroute/model_plan_unit.go
+++ b/nextroute/model_plan_unit.go
@@ -20,6 +20,9 @@ type ModelPlanUnit interface {
 	// Index returns the index of the invoking unit.
 	Index() int
 
+	// IsFixed returns true if the PlanUnit is fixed.
+	IsFixed() bool
+
 	// NumberOfStops returns the number of stops in the invoking unit.
 	NumberOfStops() int
 


### PR DESCRIPTION
# Description

Adds `IsFixed` to `PlanUnit` to check whether the plan unit is fixed.