### PR TITLE
Add min stops config options

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -43,6 +43,7 @@ type Options struct {
 		} `json:"enable"`
 	} `json:"constraints"`
 	Objectives struct {
+		MinStops                 float64 `json:"min_stops" usage:"factor to weigh the min stops objective" default:"0.0"`
 		EarlyArrivalPenalty      float64 `json:"early_arrival_penalty" usage:"factor to weigh the early arrival objective" default:"1.0"`
 		LateArrivalPenalty       float64 `json:"late_arrival_penalty" usage:"factor to weigh the late arrival objective" default:"1.0"`
 		VehicleActivationPenalty float64 `json:"vehicle_activation_penalty" usage:"factor to weigh the vehicle activation objective" default:"1.0"`

--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -33,6 +33,8 @@ type VehicleDefaults struct {
 	Speed                   *float64   `json:"speed,omitempty"`
 	StartTime               *time.Time `json:"start_time,omitempty"`
 	EndTime                 *time.Time `json:"end_time,omitempty"`
+	MinStops                *int       `json:"min_stops,omitempty"`
+	MinStopsPenalty         *float64   `json:"min_stops_penalty,omitempty"`
 	MaxStops                *int       `json:"max_stops,omitempty"`
 	MaxDistance             *int       `json:"max_distance,omitempty"`
 	MaxDuration             *int       `json:"max_duration,omitempty"`
@@ -65,6 +67,8 @@ type Vehicle struct {
 	StartTime               *time.Time     `json:"start_time,omitempty"`
 	EndTime                 *time.Time     `json:"end_time,omitempty"`
 	EndLocation             *Location      `json:"end_location,omitempty"`
+	MinStops                *int           `json:"min_stops,omitempty"`
+	MinStopsPenalty         *float64       `json:"min_stops_penalty,omitempty"`
 	MaxStops                *int           `json:"max_stops,omitempty"`
 	Speed                   *float64       `json:"speed,omitempty"`
 	MaxDuration             *int           `json:"max_duration,omitempty"`


### PR DESCRIPTION
# Description

This PR adds the ability to activate and configure the `min_stops` objective. By default this objective is deactivated. It can be activated by passing `-model.objectives.minstops 1.0` as an argument.
To configure the minimum number of stops, you can either use the `vehicle_defaults` and/or configure each vehicle individually by adding the `min_stops` and `min_stops_penalty` to your input. `min_stops` defines the minimum number of stops a vehicle should have (if it is used at all). The `min_stops_penalty` will penalize any difference between the actual number of stops in the route and the configured minimum of the number of stops in the route is smaller than the configured minimum.