### PR TITLE
propagate error rather than sending a new error when occurs for osrm

### DIFF
--- a/route/osrm/matrix.go
+++ b/route/osrm/matrix.go
@@ -22,7 +22,7 @@ func DistanceMatrix(
 ) (route.ByIndex, error) {
 	p1, _, err := c.Table(points, WithDistance(), ParallelRuns(parallelQueries))
 	if err != nil {
-		return nil, fmt.Errorf("fetching matrix: %v", err)
+		return nil, err
 	}
 
 	return overrideZeroes(route.Matrix(p1), points), nil


### PR DESCRIPTION
# Summary

We were sending a new error rather than propagating the error from `DistanceMatrix` which hides the user input error raised from below. This fixes that issue.