### PR TITLE
Improve RangeMap performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb h1:mIKbk8weKhSeLH2GmUTrvx8CjkyJmnU1wFmg59CUjFA=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/nextroute/common/utils.go
+++ b/nextroute/common/utils.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/slices"
 )
 
 // Filter filters a slice using a predicate function.
@@ -388,12 +389,12 @@ func RangeMap[M ~map[K]V, K Comparable, V any](
 	f func(key K, value V) bool,
 ) {
 	keys := make([]K, 0, len(m))
+	i := 0
 	for k := range m {
-		keys = append(keys, k)
+		keys[i] = k
+		i++
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] < keys[j]
-	})
+	slices.Sort(keys)
 	for _, k := range keys {
 		if f(k, m[k]) {
 			break

--- a/nextroute/common/utils.go
+++ b/nextroute/common/utils.go
@@ -388,7 +388,7 @@ func RangeMap[M ~map[K]V, K Comparable, V any](
 	m M,
 	f func(key K, value V) bool,
 ) {
-	keys := make([]K, 0, len(m))
+	keys := make([]K, len(m))
 	i := 0
 	for k := range m {
 		keys[i] = k


### PR DESCRIPTION
# Description

By using `slices.Sort` (vs sort.Slice) and assigning via index (vs append) we can improve the performance of `RangeMap`.