### PR TITLE
Add iterations to run section of statistics

### DIFF
--- a/run/generic_runner.go
+++ b/run/generic_runner.go
@@ -7,13 +7,18 @@ import (
 	"reflect"
 	"runtime"
 	"runtime/pprof"
+	"sync"
 	"time"
 )
 
 type start string
+type data string
 
 // Start is the key for the start time of the run.
 const Start start = "start"
+
+// Data is the key for additional data of the run.
+const Data data = "data"
 
 // GenericRunner creates a new runner from the given components.
 func GenericRunner[RunnerConfig, Input, Option, Solution any](
@@ -115,6 +120,7 @@ func (r *genericRunner[RunnerConfig, Input, Option, Solution]) Run(
 ) (retErr error) {
 	start := time.Now()
 	ctx = context.WithValue(ctx, Start, start)
+	ctx = context.WithValue(ctx, Data, &sync.Map{})
 	// handle CPU profile
 	deferFuncCPU, retErr := r.handleCPUProfile(r.runnerConfig)
 	if retErr != nil {

--- a/run/statistics/schema.go
+++ b/run/statistics/schema.go
@@ -19,8 +19,9 @@ type Statistics struct {
 
 // Run is the structure of the run section of the statistics.
 type Run struct {
-	Duration *float64 `json:"duration,omitempty"`
-	Custom   any      `json:"custom,omitempty"`
+	Duration   *float64 `json:"duration,omitempty"`
+	Iterations *int     `json:"iterations,omitempty"`
+	Custom     any      `json:"custom,omitempty"`
 }
 
 // Result is the structure of the result section of the statistics.


### PR DESCRIPTION
# Description

For performance comparisons it can be interesting to look at iterations performed. This PR adds `Iterations` to the `Run` section of `statistics`.