### PR TITLE
Uses 0/unlimited as the defaul osrm snap radius

### DIFF
--- a/route/osrm/client.go
+++ b/route/osrm/client.go
@@ -72,7 +72,7 @@ func NewClient(host string, opts ...ClientOption) Client {
 	c := &client{
 		host:         host,
 		httpClient:   http.DefaultClient,
-		snapRadius:   1000,
+		snapRadius:   0,
 		maxTableSize: 100,
 		scaleFactor:  1.0,
 	}


### PR DESCRIPTION
# Description

Change the default OSRM snap radius to unlimited (same as OSRM's default).

## Changes

- Changes default OSRM snap radius to unlimited