### PR TITLE
feature/eng-3702-add-legacy-output-to-nextroute

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -209,6 +209,10 @@ issues:
     - path: alns/solver\.go
       linters:
         - nestif
+    # Cloud code for compatibility
+    - path: nextroute/schema/fleet_defaults\.go
+      linters:
+        - gocyclo
 
     # Using math/rand is fine here
     - path: nextroute/common/alias_test\.go

--- a/nextroute/schema/fleet.go
+++ b/nextroute/schema/fleet.go
@@ -132,25 +132,7 @@ const dynamicDefaultKey = "default"
 
 // ToNextRoute converters a legacy cloud fleet input into nextroute input format.
 func (fleetInput FleetInput) ToNextRoute() (Input, error) {
-	input := Input{
-		//Defaults: &Defaults{},
-	}
-	// stopCompats := make([]string, 0)
-	// vehicleCompats := make([]string, 0)
-	// // Use default values and add special handling for CompatibilityAttributes
-	// // and HardWindows.
-	// input, stopCompats = stopDefaults(fleetInput, input, stopCompats)
-
-	// // Use default values. nil values are not compatible between fleet and
-	// // nextroute.
-	// input, vehicleCompats = vehicleDefaults(fleetInput, vehicleCompats, input)
-
-	// Handle special case of compatibility attributes, to use them to make
-	// legacy backlogs more or less work like in legacy fleet.
-	// for i := range fleetInput.Vehicles {
-	// 	fleetInput.Vehicles[i].CompatibilityAttributes =
-	// 		append(fleetInput.Vehicles[i].CompatibilityAttributes, vehicleCompats...)
-	// }
+	input := Input{}
 
 	fleetInput.applyStopDefaults()
 	fleetInput.applyVehicleDefaults()
@@ -222,6 +204,9 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 				if !ok {
 					return input, fmt.Errorf("could not convert quantity for stop %s to int", backlogStop.ID)
 				}
+				if _, ok := startLevel[k]; !ok {
+					startLevel[k] = 0
+				}
 				currentLevel, ok := convertToInt(startLevel[k])
 				if !ok {
 					return input, fmt.Errorf("could not convert quantity for stop %s to int", backlogStop.ID)
@@ -253,12 +238,6 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 		}
 	}
 
-	// for i, s := range fleetInput.Stops {
-	// 	if _, ok := backlogStops[s.ID]; !ok && s.CompatibilityAttributes == nil {
-	// 		fleetInput.Stops[i].CompatibilityAttributes = &stopCompats
-	// 	}
-	// }
-
 	// Create stops with legacy backlog feature.
 	stops := createStops(fleetInput, backlogStops)
 
@@ -274,50 +253,6 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 
 	return input, nil
 }
-
-// func stopDefaults(fleetInput FleetInput, input Input, stopCompats []string) (Input, []string) {
-// 	if fleetInput.Defaults != nil && fleetInput.Defaults.Stops != nil {
-// 		input.Defaults.Stops = &StopDefaults{
-// 			UnplannedPenalty:        fleetInput.Defaults.Stops.UnassignedPenalty,
-// 			Quantity:                fleetInput.Defaults.Stops.Quantity,
-// 			MaxWait:                 fleetInput.Defaults.Stops.MaxWait,
-// 			Duration:                fleetInput.Defaults.Stops.StopDuration,
-// 			TargetArrivalTime:       fleetInput.Defaults.Stops.TargetTime,
-// 			EarlyArrivalTimePenalty: fleetInput.Defaults.Stops.EarlinessPenalty,
-// 			LateArrivalTimePenalty:  fleetInput.Defaults.Stops.LatenessPenalty,
-// 		}
-// 		if fleetInput.Defaults.Stops.CompatibilityAttributes != nil {
-// 			stopCompats = *fleetInput.Defaults.Stops.CompatibilityAttributes
-// 		}
-// 		if fleetInput.Defaults.Stops.HardWindow != nil {
-// 			input.Defaults.Stops.StartTimeWindow = *fleetInput.Defaults.Stops.HardWindow
-// 		}
-// 	}
-// 	return input, stopCompats
-// }
-
-// func vehicleDefaults(fleetInput FleetInput, vehicleCompats []string, input Input) (Input, []string) {
-// 	if fleetInput.Defaults != nil && fleetInput.Defaults.Vehicles != nil {
-// 		vehicleCompats = fleetInput.Defaults.Vehicles.CompatibilityAttributes
-// 		input.Defaults.Vehicles = &VehicleDefaults{
-// 			Capacity:          fleetInput.Defaults.Vehicles.Capacity,
-// 			StartLocation:     fleetInput.Defaults.Vehicles.Start,
-// 			EndLocation:       fleetInput.Defaults.Vehicles.End,
-// 			Speed:             fleetInput.Defaults.Vehicles.Speed,
-// 			StartTime:         fleetInput.Defaults.Vehicles.ShiftStart,
-// 			EndTime:           fleetInput.Defaults.Vehicles.ShiftEnd,
-// 			MaxStops:          fleetInput.Defaults.Vehicles.MaxStops,
-// 			MaxDistance:       fleetInput.Defaults.Vehicles.MaxDistance,
-// 			MaxDuration:       fleetInput.Defaults.Vehicles.MaxDuration,
-// 			StartLevel:        nil,
-// 			MinStops:          nil,
-// 			MinStopsPenalty:   nil,
-// 			MaxWait:           nil,
-// 			ActivationPenalty: nil,
-// 		}
-// 	}
-// 	return input, vehicleCompats
-// }
 
 func (fleetInput *FleetInput) stopMapUpdate() (map[string]FleetStop, error) {
 	stopMap := make(map[string]FleetStop)

--- a/nextroute/schema/fleet.go
+++ b/nextroute/schema/fleet.go
@@ -105,6 +105,16 @@ type FleetStop struct {
 // maintained. It will be deleted soon. Please use [solve.Options] instead.
 type Options struct {
 	Solver *SolverOptions `json:"solver,omitempty"`
+	Runner *RunnerOptions `json:"runner,omitempty"`
+}
+
+// RunnerOptions represent the solver runtime duration in legacy fleet.
+// DEPRECATION NOTICE: this part of the API is deprecated and is no longer
+// maintained. It will be deleted soon. Please use [solve.Options] instead.
+type RunnerOptions struct {
+	Output struct {
+		Solutions string `json:"solutions,omitempty"`
+	} `json:"output,omitempty"`
 }
 
 // SolverOptions represent the solver runtime duration in legacy fleet.

--- a/nextroute/schema/fleet.go
+++ b/nextroute/schema/fleet.go
@@ -254,8 +254,12 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 	stops := createStops(fleetInput, backlogStops)
 
 	// Put new input format together and return it.
-	input.StopGroups = &fleetInput.StopGroups
-	input.DurationGroups = &fleetInput.DurationGroups
+	if fleetInput.StopGroups != nil {
+		input.StopGroups = &fleetInput.StopGroups
+	}
+	if fleetInput.DurationGroups != nil {
+		input.DurationGroups = &fleetInput.DurationGroups
+	}
 	input.Vehicles = vehicles
 	input.Stops = stops
 

--- a/nextroute/schema/fleet.go
+++ b/nextroute/schema/fleet.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"time"
 )
@@ -65,11 +66,12 @@ type FleetStopDefaults struct {
 // DEPRECATION NOTICE: this part of the API is deprecated and is no longer
 // maintained. It will be deleted soon. Please use [Vehicle] instead.
 type FleetVehicle struct {
-	ID                      string     `json:"id,omitempty"`
-	Start                   *Location  `json:"start,omitempty"`
-	End                     *Location  `json:"end,omitempty"`
-	Speed                   *float64   `json:"speed,omitempty"`
-	Capacity                any        `json:"capacity,omitempty"`
+	ID                      string    `json:"id,omitempty"`
+	Start                   *Location `json:"start,omitempty"`
+	End                     *Location `json:"end,omitempty"`
+	Speed                   *float64  `json:"speed,omitempty"`
+	Capacity                any       `json:"capacity,omitempty"`
+	capacity                map[string]int
 	ShiftStart              *time.Time `json:"shift_start,omitempty"`
 	ShiftEnd                *time.Time `json:"shift_end,omitempty"`
 	CompatibilityAttributes []string   `json:"compatibility_attributes,omitempty"`
@@ -90,7 +92,8 @@ type FleetStop struct {
 	Position                Location `json:"position,omitempty"`
 	UnassignedPenalty       *int     `json:"unassigned_penalty,omitempty"`
 	Quantity                any      `json:"quantity,omitempty"`
-	Precedes                any      `json:"precedes,omitempty"`
+	quantity                map[string]int
+	Precedes                any `json:"precedes,omitempty"`
 	precedes                []string
 	Succeeds                any `json:"succeeds,omitempty"`
 	succeeds                []string
@@ -124,61 +127,33 @@ type Limits struct {
 	Duration string `json:"duration,omitempty"`
 }
 
+// dynamicDefaultKey is used when only scalar quantities / capacities are given.
+const dynamicDefaultKey = "default"
+
 // ToNextRoute converters a legacy cloud fleet input into nextroute input format.
 func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 	input := Input{
-		Defaults: &Defaults{},
+		//Defaults: &Defaults{},
 	}
-	stopCompats := make([]string, 0)
-	vehicleCompats := make([]string, 0)
-	// Use default values and add special handling for CompatibilityAttributes
-	// and HardWindows.
-	if fleetInput.Defaults != nil && fleetInput.Defaults.Stops != nil {
-		input.Defaults.Stops = &StopDefaults{
-			UnplannedPenalty:        fleetInput.Defaults.Stops.UnassignedPenalty,
-			Quantity:                fleetInput.Defaults.Stops.Quantity,
-			MaxWait:                 fleetInput.Defaults.Stops.MaxWait,
-			Duration:                fleetInput.Defaults.Stops.StopDuration,
-			TargetArrivalTime:       fleetInput.Defaults.Stops.TargetTime,
-			EarlyArrivalTimePenalty: fleetInput.Defaults.Stops.EarlinessPenalty,
-			LateArrivalTimePenalty:  fleetInput.Defaults.Stops.LatenessPenalty,
-		}
-		if fleetInput.Defaults.Stops.CompatibilityAttributes != nil {
-			stopCompats = *fleetInput.Defaults.Stops.CompatibilityAttributes
-		}
-		if fleetInput.Defaults.Stops.HardWindow != nil {
-			input.Defaults.Stops.StartTimeWindow = *fleetInput.Defaults.Stops.HardWindow
-		}
-	}
+	// stopCompats := make([]string, 0)
+	// vehicleCompats := make([]string, 0)
+	// // Use default values and add special handling for CompatibilityAttributes
+	// // and HardWindows.
+	// input, stopCompats = stopDefaults(fleetInput, input, stopCompats)
 
-	// Use default values. nil values are not compatible between fleet and
-	// nextroute.
-	if fleetInput.Defaults != nil && fleetInput.Defaults.Vehicles != nil {
-		vehicleCompats = fleetInput.Defaults.Vehicles.CompatibilityAttributes
-		input.Defaults.Vehicles = &VehicleDefaults{
-			Capacity:          fleetInput.Defaults.Vehicles.Capacity,
-			StartLocation:     fleetInput.Defaults.Vehicles.Start,
-			EndLocation:       fleetInput.Defaults.Vehicles.End,
-			Speed:             fleetInput.Defaults.Vehicles.Speed,
-			StartTime:         fleetInput.Defaults.Vehicles.ShiftStart,
-			EndTime:           fleetInput.Defaults.Vehicles.ShiftEnd,
-			MaxStops:          fleetInput.Defaults.Vehicles.MaxStops,
-			MaxDistance:       fleetInput.Defaults.Vehicles.MaxDistance,
-			MaxDuration:       fleetInput.Defaults.Vehicles.MaxDuration,
-			StartLevel:        nil,
-			MinStops:          nil,
-			MinStopsPenalty:   nil,
-			MaxWait:           nil,
-			ActivationPenalty: nil,
-		}
-	}
+	// // Use default values. nil values are not compatible between fleet and
+	// // nextroute.
+	// input, vehicleCompats = vehicleDefaults(fleetInput, vehicleCompats, input)
 
 	// Handle special case of compatibility attributes, to use them to make
 	// legacy backlogs more or less work like in legacy fleet.
-	for i := range fleetInput.Vehicles {
-		fleetInput.Vehicles[i].CompatibilityAttributes =
-			append(fleetInput.Vehicles[i].CompatibilityAttributes, vehicleCompats...)
-	}
+	// for i := range fleetInput.Vehicles {
+	// 	fleetInput.Vehicles[i].CompatibilityAttributes =
+	// 		append(fleetInput.Vehicles[i].CompatibilityAttributes, vehicleCompats...)
+	// }
+
+	fleetInput.applyStopDefaults()
+	fleetInput.applyVehicleDefaults()
 
 	// Get stopMap and update precedes/succeeds any fields.
 	stopMap, err := fleetInput.stopMapUpdate()
@@ -193,36 +168,61 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 		v := v
 		newAttributes := make([]string, len(v.CompatibilityAttributes))
 		copy(newAttributes, v.CompatibilityAttributes)
-		for _, ca := range v.CompatibilityAttributes {
+		if len(v.CompatibilityAttributes) > 0 {
 			for _, b := range v.Backlog {
-				newAttributes = append(newAttributes, fmt.Sprintf("%s_%s", ca, b))
+				for _, ca := range v.CompatibilityAttributes {
+					newAttributes = append(newAttributes, fmt.Sprintf("%s_%s", ca, b))
+				}
 			}
+		} else {
+			newAttributes = append(newAttributes, v.Backlog...)
 		}
 		newBacklog := make([]InitialStop, 0)
 		falseBool := false
+		isInBacklog := make(map[string]struct{})
+		startLevel := make(map[string]int)
 		for _, b := range v.Backlog {
 			backlogStops[b] = struct{}{}
-			newBacklog = append(newBacklog, InitialStop{
-				Fixed: &falseBool,
-				ID:    b,
-			})
 			backlogStop := stopMap[b]
-			for _, p := range backlogStop.precedes {
+			if _, ok := isInBacklog[b]; !ok {
 				newBacklog = append(newBacklog, InitialStop{
 					Fixed: &falseBool,
-					ID:    p,
+					ID:    b,
 				})
+				isInBacklog[b] = struct{}{}
+			}
+
+			for _, p := range backlogStop.precedes {
+				if _, ok := isInBacklog[p]; !ok {
+					newBacklog = append(newBacklog, InitialStop{
+						Fixed: &falseBool,
+						ID:    p,
+					})
+					backlogStops[p] = struct{}{}
+					isInBacklog[p] = struct{}{}
+				}
 			}
 
 			for _, s := range backlogStop.succeeds {
-				newBacklog = append(newBacklog, InitialStop{
-					Fixed: &falseBool,
-					ID:    s,
-				})
+				if _, ok := isInBacklog[s]; !ok {
+					newBacklog = append(newBacklog, InitialStop{
+						Fixed: &falseBool,
+						ID:    s,
+					})
+					backlogStops[s] = struct{}{}
+					isInBacklog[s] = struct{}{}
+				}
+			}
+		}
+
+		for _, b := range newBacklog {
+			backlogStop := stopMap[b.ID]
+			for k, q := range backlogStop.quantity {
+				startLevel[k] += q
 			}
 		}
 		vehicles[i] = Vehicle{
-			Capacity:                v.Capacity,
+			Capacity:                v.capacity,
 			CompatibilityAttributes: &newAttributes,
 			MaxDistance:             v.MaxDistance,
 			StopDurationMultiplier:  v.StopDurationMultiplier,
@@ -236,7 +236,7 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 			InitialStops:            &newBacklog,
 			ActivationPenalty:       &v.InitializationCost,
 			ID:                      v.ID,
-			StartLevel:              nil,
+			StartLevel:              startLevel,
 			CustomData:              nil,
 			MinStops:                nil,
 			MinStopsPenalty:         nil,
@@ -244,11 +244,11 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 		}
 	}
 
-	for i, s := range fleetInput.Stops {
-		if _, ok := backlogStops[s.ID]; !ok && s.CompatibilityAttributes == nil {
-			fleetInput.Stops[i].CompatibilityAttributes = &stopCompats
-		}
-	}
+	// for i, s := range fleetInput.Stops {
+	// 	if _, ok := backlogStops[s.ID]; !ok && s.CompatibilityAttributes == nil {
+	// 		fleetInput.Stops[i].CompatibilityAttributes = &stopCompats
+	// 	}
+	// }
 
 	// Create stops with legacy backlog feature.
 	stops := createStops(fleetInput, backlogStops)
@@ -265,6 +265,50 @@ func (fleetInput FleetInput) ToNextRoute() (Input, error) {
 
 	return input, nil
 }
+
+// func stopDefaults(fleetInput FleetInput, input Input, stopCompats []string) (Input, []string) {
+// 	if fleetInput.Defaults != nil && fleetInput.Defaults.Stops != nil {
+// 		input.Defaults.Stops = &StopDefaults{
+// 			UnplannedPenalty:        fleetInput.Defaults.Stops.UnassignedPenalty,
+// 			Quantity:                fleetInput.Defaults.Stops.Quantity,
+// 			MaxWait:                 fleetInput.Defaults.Stops.MaxWait,
+// 			Duration:                fleetInput.Defaults.Stops.StopDuration,
+// 			TargetArrivalTime:       fleetInput.Defaults.Stops.TargetTime,
+// 			EarlyArrivalTimePenalty: fleetInput.Defaults.Stops.EarlinessPenalty,
+// 			LateArrivalTimePenalty:  fleetInput.Defaults.Stops.LatenessPenalty,
+// 		}
+// 		if fleetInput.Defaults.Stops.CompatibilityAttributes != nil {
+// 			stopCompats = *fleetInput.Defaults.Stops.CompatibilityAttributes
+// 		}
+// 		if fleetInput.Defaults.Stops.HardWindow != nil {
+// 			input.Defaults.Stops.StartTimeWindow = *fleetInput.Defaults.Stops.HardWindow
+// 		}
+// 	}
+// 	return input, stopCompats
+// }
+
+// func vehicleDefaults(fleetInput FleetInput, vehicleCompats []string, input Input) (Input, []string) {
+// 	if fleetInput.Defaults != nil && fleetInput.Defaults.Vehicles != nil {
+// 		vehicleCompats = fleetInput.Defaults.Vehicles.CompatibilityAttributes
+// 		input.Defaults.Vehicles = &VehicleDefaults{
+// 			Capacity:          fleetInput.Defaults.Vehicles.Capacity,
+// 			StartLocation:     fleetInput.Defaults.Vehicles.Start,
+// 			EndLocation:       fleetInput.Defaults.Vehicles.End,
+// 			Speed:             fleetInput.Defaults.Vehicles.Speed,
+// 			StartTime:         fleetInput.Defaults.Vehicles.ShiftStart,
+// 			EndTime:           fleetInput.Defaults.Vehicles.ShiftEnd,
+// 			MaxStops:          fleetInput.Defaults.Vehicles.MaxStops,
+// 			MaxDistance:       fleetInput.Defaults.Vehicles.MaxDistance,
+// 			MaxDuration:       fleetInput.Defaults.Vehicles.MaxDuration,
+// 			StartLevel:        nil,
+// 			MinStops:          nil,
+// 			MinStopsPenalty:   nil,
+// 			MaxWait:           nil,
+// 			ActivationPenalty: nil,
+// 		}
+// 	}
+// 	return input, vehicleCompats
+// }
 
 func (fleetInput *FleetInput) stopMapUpdate() (map[string]FleetStop, error) {
 	stopMap := make(map[string]FleetStop)
@@ -310,16 +354,79 @@ func (fleetInput *FleetInput) stopMapUpdate() (map[string]FleetStop, error) {
 			}
 			fleetInput.Stops[idx].succeeds = []string{succeeds}
 		}
+
+		// Handle multi capacity fields
+		if reflect.ValueOf(stop.Quantity).Kind() == reflect.Map {
+			// We detected a map and need to handle it
+			quantities, ok := stop.Quantity.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("could not parse Quanitity field for stop %s", stop.ID)
+			}
+			// Init map
+			fleetInput.Stops[idx].quantity = map[string]int{}
+			// Set all values
+			for kind, quant := range quantities {
+				rounded, ok := convertToInt(quant)
+				if !ok {
+					return nil, fmt.Errorf("could not parse Quanitity field for stop %s", stop.ID)
+				}
+				fleetInput.Stops[idx].quantity[kind] = rounded
+			}
+		} else {
+			// Since it is not a map, we expect a scalar value
+			quantity, ok := convertToInt(stop.Quantity)
+			if !ok {
+				return nil, fmt.Errorf("could not parse Quanitity field for stop %s", stop.ID)
+			}
+			fleetInput.Stops[idx].quantity = map[string]int{
+				dynamicDefaultKey: quantity,
+			}
+		}
 		stopMap[stop.ID] = fleetInput.Stops[idx]
 	}
+	for v, vehicle := range fleetInput.Vehicles {
+		vehicle, err := handleCapacity(vehicle)
+		if err != nil {
+			return stopMap, err
+		}
+		fleetInput.Vehicles[v] = vehicle
+	}
 	return stopMap, nil
+}
+
+func handleCapacity(vehicle FleetVehicle) (FleetVehicle, error) {
+	if reflect.ValueOf(vehicle.Capacity).Kind() == reflect.Map {
+		capacities, ok := vehicle.Capacity.(map[string]interface{})
+		if !ok {
+			return vehicle, fmt.Errorf("could not parse Capacity field for vehicle %s", vehicle.ID)
+		}
+
+		vehicle.capacity = map[string]int{}
+
+		for kind, cap := range capacities {
+			rounded, ok := convertToInt(cap)
+			if !ok {
+				return vehicle, fmt.Errorf("could not parse Capacity field for vehicle %s", vehicle.ID)
+			}
+			vehicle.capacity[kind] = rounded
+		}
+	} else {
+		capacity, ok := convertToInt(vehicle.Capacity)
+		if !ok {
+			return vehicle, fmt.Errorf("could not parse Capacity field for vehicle %s", vehicle.ID)
+		}
+		vehicle.capacity = map[string]int{
+			dynamicDefaultKey: capacity,
+		}
+	}
+	return vehicle, nil
 }
 
 func createStops(fleetInput FleetInput, backlogStops map[string]struct{}) []Stop {
 	stops := make([]Stop, len(fleetInput.Stops))
 	for i, s := range fleetInput.Stops {
 		compats := make([]string, 0)
-		if s.CompatibilityAttributes != nil {
+		if s.CompatibilityAttributes != nil && len(*s.CompatibilityAttributes) > 0 {
 			if _, ok := backlogStops[s.ID]; ok {
 				for _, ca := range *s.CompatibilityAttributes {
 					compats = append(compats, fmt.Sprintf("%s_%s", ca, s.ID))
@@ -327,10 +434,12 @@ func createStops(fleetInput FleetInput, backlogStops map[string]struct{}) []Stop
 			} else {
 				compats = *s.CompatibilityAttributes
 			}
+		} else if _, ok := backlogStops[s.ID]; ok {
+			compats = append(compats, s.ID)
 		}
 		stops[i] = Stop{
 			Precedes:                s.Precedes,
-			Quantity:                s.Quantity,
+			Quantity:                s.quantity,
 			Succeeds:                s.Succeeds,
 			Duration:                s.StopDuration,
 			MaxWait:                 s.MaxWait,
@@ -359,4 +468,28 @@ func roundToMinute(t time.Time) time.Time {
 		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute()+1, 0, 0, t.Location())
 	}
 	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), 0, 0, t.Location())
+}
+
+// intTolerance specified the absolute offset tolerable for dynamic fields that
+// are naturally float, but where integer values are expected.
+const intTolerance = 0.00001
+
+// convertToInt tries to convert the given unknown typed value to int. Returns
+// true, iff the conversion was successful.
+func convertToInt(unknown interface{}) (int, bool) {
+	// Convert unknown to float
+	floatType := reflect.TypeOf(float64(0))
+	v := reflect.ValueOf(unknown)
+	v = reflect.Indirect(v)
+	if !v.Type().ConvertibleTo(floatType) {
+		return 0, false
+	}
+	fv := v.Convert(floatType)
+	floatValue := fv.Float()
+	// Round to next int (not ok if offset out of tolerance)
+	rounded := math.Round(floatValue)
+	if math.Abs(rounded-floatValue) > intTolerance {
+		return 0, false
+	}
+	return int(rounded), true
 }

--- a/nextroute/schema/fleet_defaults.go
+++ b/nextroute/schema/fleet_defaults.go
@@ -1,0 +1,160 @@
+// Package schema provides the input and output schema for nextroute.
+package schema
+
+func (fleetInput *FleetInput) applyVehicleDefaults() {
+	// Specify some defaults for missing values
+	capacity := 0
+	vehicleCompatibilities := []string{}
+
+	// Apply all vehicle defaults, if no explicit value is set
+	// Apply general default, if neither explicit nor default value is given
+	for v := range fleetInput.Vehicles {
+		vehicleDefaults := fleetInput.Defaults != nil && fleetInput.Defaults.Vehicles != nil
+		if fleetInput.Vehicles[v].Start == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.Start != nil {
+				fleetInput.Vehicles[v].Start = fleetInput.Defaults.Vehicles.Start
+			}
+		}
+
+		if fleetInput.Vehicles[v].End == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.End != nil {
+				fleetInput.Vehicles[v].End = fleetInput.Defaults.Vehicles.End
+			}
+		}
+
+		if fleetInput.Vehicles[v].Speed == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.Speed != nil {
+				fleetInput.Vehicles[v].Speed = fleetInput.Defaults.Vehicles.Speed
+			}
+		}
+
+		if fleetInput.Vehicles[v].Capacity == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.Capacity != nil {
+				fleetInput.Vehicles[v].Capacity = fleetInput.Defaults.Vehicles.Capacity
+			} else {
+				fleetInput.Vehicles[v].Capacity = &capacity
+			}
+		}
+
+		if fleetInput.Vehicles[v].ShiftStart == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.ShiftStart != nil {
+				fleetInput.Vehicles[v].ShiftStart = fleetInput.Defaults.Vehicles.ShiftStart
+			}
+		}
+
+		if fleetInput.Vehicles[v].ShiftEnd == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.ShiftEnd != nil {
+				fleetInput.Vehicles[v].ShiftEnd = fleetInput.Defaults.Vehicles.ShiftEnd
+			}
+		}
+
+		if fleetInput.Vehicles[v].CompatibilityAttributes == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.CompatibilityAttributes != nil {
+				fleetInput.Vehicles[v].CompatibilityAttributes = fleetInput.Defaults.Vehicles.CompatibilityAttributes
+			} else {
+				fleetInput.Vehicles[v].CompatibilityAttributes = vehicleCompatibilities
+			}
+		}
+
+		if fleetInput.Vehicles[v].MaxStops == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.MaxStops != nil {
+				fleetInput.Vehicles[v].MaxStops = fleetInput.Defaults.Vehicles.MaxStops
+			}
+		}
+
+		if fleetInput.Vehicles[v].MaxDistance == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.MaxDistance != nil {
+				fleetInput.Vehicles[v].MaxDistance = fleetInput.Defaults.Vehicles.MaxDistance
+			}
+		}
+
+		if fleetInput.Vehicles[v].MaxDuration == nil {
+			if vehicleDefaults && fleetInput.Defaults.Vehicles.MaxDuration != nil {
+				fleetInput.Vehicles[v].MaxDuration = fleetInput.Defaults.Vehicles.MaxDuration
+			}
+		}
+
+		if fleetInput.Vehicles[v].StopDurationMultiplier == nil {
+			multiplier := 1.0
+			fleetInput.Vehicles[v].StopDurationMultiplier = &multiplier
+		}
+	}
+}
+
+// applyStopDefaults applies the given default values for all values of vehicles
+// and stops not explicitly defined.
+func (fleetInput *FleetInput) applyStopDefaults() {
+	// Specify some defaults for missing values
+	unassignedPenalty := 0
+	quantity := 0
+	stopDuration := 0
+	stopCompatibilities := []string{}
+
+	// Apply all vehicle defaults, if no explicit value is set
+	// Apply general default, if neither explicit nor default value is given
+	for s := range fleetInput.Stops {
+		stopDefaults := fleetInput.Defaults != nil && fleetInput.Defaults.Stops != nil
+
+		if fleetInput.Stops[s].UnassignedPenalty == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.UnassignedPenalty != nil {
+				fleetInput.Stops[s].UnassignedPenalty = fleetInput.Defaults.Stops.UnassignedPenalty
+			} else {
+				fleetInput.Stops[s].UnassignedPenalty = &unassignedPenalty
+			}
+		}
+
+		if fleetInput.Stops[s].Quantity == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.Quantity != nil {
+				fleetInput.Stops[s].Quantity = fleetInput.Defaults.Stops.Quantity
+			} else {
+				fleetInput.Stops[s].Quantity = &quantity
+			}
+		}
+
+		if fleetInput.Stops[s].HardWindow == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.HardWindow != nil {
+				fleetInput.Stops[s].HardWindow = fleetInput.Defaults.Stops.HardWindow
+			}
+		}
+
+		if fleetInput.Stops[s].MaxWait == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.MaxWait != nil {
+				fleetInput.Stops[s].MaxWait = fleetInput.Defaults.Stops.MaxWait
+			}
+		}
+
+		if fleetInput.Stops[s].StopDuration == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.StopDuration != nil {
+				fleetInput.Stops[s].StopDuration = fleetInput.Defaults.Stops.StopDuration
+			} else {
+				fleetInput.Stops[s].StopDuration = &stopDuration
+			}
+		}
+
+		if fleetInput.Stops[s].TargetTime == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.TargetTime != nil {
+				fleetInput.Stops[s].TargetTime = fleetInput.Defaults.Stops.TargetTime
+			}
+		}
+
+		if fleetInput.Stops[s].EarlinessPenalty == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.EarlinessPenalty != nil {
+				fleetInput.Stops[s].EarlinessPenalty = fleetInput.Defaults.Stops.EarlinessPenalty
+			}
+		}
+
+		if fleetInput.Stops[s].LatenessPenalty == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.LatenessPenalty != nil {
+				fleetInput.Stops[s].LatenessPenalty = fleetInput.Defaults.Stops.LatenessPenalty
+			}
+		}
+
+		if fleetInput.Stops[s].CompatibilityAttributes == nil {
+			if stopDefaults && fleetInput.Defaults.Stops.CompatibilityAttributes != nil {
+				fleetInput.Stops[s].CompatibilityAttributes = fleetInput.Defaults.Stops.CompatibilityAttributes
+			} else {
+				fleetInput.Stops[s].CompatibilityAttributes = &stopCompatibilities
+			}
+		}
+	}
+}

--- a/nextroute/schema/fleet_test.go
+++ b/nextroute/schema/fleet_test.go
@@ -158,37 +158,6 @@ const fleetInputData = `{
   }`
 
 const nextrouteInputWant = `{
-  "defaults": {
-    "vehicles": {
-      "capacity": 10,
-      "start_location": {
-        "lon": -96.659222,
-        "lat": 33.122746
-      },
-      "end_location": {
-        "lon": -96.659222,
-        "lat": 33.122746
-      },
-      "speed": 20,
-      "start_time": "2021-10-17T09:00:00-06:00",
-      "end_time": "2021-10-17T11:00:00-06:00",
-      "max_stops": 15,
-      "max_distance": 100000,
-      "max_duration": 50000
-    },
-    "stops": {
-      "unplanned_penalty": 200000,
-      "quantity": -5,
-      "start_time_window": [
-        "2021-10-17T09:00:00-06:00",
-        "2021-10-17T10:00:00-06:00"
-      ],
-      "max_wait": 300,
-      "duration": 120,
-      "early_arrival_time_penalty": 2,
-      "late_arrival_time_penalty": 5
-    }
-  },
   "stop_groups": [
     [
       "order-24-pickup-1",
@@ -206,7 +175,12 @@ const nextrouteInputWant = `{
   ],
   "vehicles": [
     {
-      "capacity": 105,
+      "capacity": {
+        "default": 105
+      },
+      "start_level": {
+        "default": 0
+      },
       "compatibility_attributes": [
         "vehicle-1",
         "vehicle-1_order-24-pickup-1",
@@ -214,10 +188,13 @@ const nextrouteInputWant = `{
       ],
       "max_distance": 200000,
       "stop_duration_multiplier": 1,
+      "start_time": "2021-10-17T09:00:00-06:00",
+      "end_time": "2021-10-17T11:00:00-06:00",
       "end_location": {
         "lon": -96.659222,
         "lat": 33.122746
       },
+      "max_stops": 15,
       "speed": 14,
       "max_duration": 55000,
       "activation_penalty": 2,
@@ -238,9 +215,27 @@ const nextrouteInputWant = `{
       "id": "vehicle-1"
     },
     {
-      "capacity": 95,
+      "capacity": {
+        "default": 95
+      },
+      "start_level": {},
       "compatibility_attributes": [],
+      "max_distance": 100000,
+      "stop_duration_multiplier": 1,
+      "start_time": "2021-10-17T09:00:00-06:00",
+      "end_time": "2021-10-17T11:00:00-06:00",
+      "end_location": {
+        "lon": -96.659222,
+        "lat": 33.122746
+      },
+      "max_stops": 15,
+      "speed": 20,
+      "max_duration": 50000,
       "activation_penalty": 0,
+      "start_location": {
+        "lon": -96.659222,
+        "lat": 33.122746
+      },
       "initial_stops": [],
       "id": "vehicle-2"
     }
@@ -248,11 +243,18 @@ const nextrouteInputWant = `{
   "stops": [
     {
       "precedes": "order-1-dropoff",
-      "quantity": -27,
+      "quantity": {
+        "default": -27
+      },
+      "duration": 120,
+      "max_wait": 300,
       "start_time_window": [
         "2021-10-17T10:00:00-06:00",
         "2021-10-17T11:00:00-06:00"
       ],
+      "unplanned_penalty": 200000,
+      "early_arrival_time_penalty": 2,
+      "late_arrival_time_penalty": 5,
       "compatibility_attributes": [
         "vehicle-1"
       ],
@@ -263,11 +265,18 @@ const nextrouteInputWant = `{
       }
     },
     {
-      "quantity": 27,
+      "quantity": {
+        "default": 27
+      },
+      "duration": 120,
+      "max_wait": 300,
       "start_time_window": [
         "2021-10-17T09:00:00-06:00",
         "2021-10-17T10:00:00-06:00"
       ],
+      "unplanned_penalty": 200000,
+      "early_arrival_time_penalty": 2,
+      "late_arrival_time_penalty": 5,
       "compatibility_attributes": [
         "A"
       ],
@@ -280,7 +289,18 @@ const nextrouteInputWant = `{
     },
     {
       "precedes": "order-24-dropoff",
-      "quantity": -9,
+      "quantity": {
+        "default": -9
+      },
+      "duration": 120,
+      "max_wait": 300,
+      "start_time_window": [
+        "2021-10-17T09:00:00-06:00",
+        "2021-10-17T10:00:00-06:00"
+      ],
+      "unplanned_penalty": 200000,
+      "early_arrival_time_penalty": 2,
+      "late_arrival_time_penalty": 5,
       "compatibility_attributes": [
         "vehicle-1_order-24-pickup-1"
       ],
@@ -291,12 +311,21 @@ const nextrouteInputWant = `{
       }
     },
     {
-      "quantity": 9,
+      "quantity": {
+        "default": 9
+      },
+      "duration": 120,
+      "max_wait": 300,
       "start_time_window": [
         "2021-10-17T09:31:00-06:00",
         "2021-10-17T12:00:00-06:00"
       ],
-      "compatibility_attributes": [],
+      "unplanned_penalty": 200000,
+      "early_arrival_time_penalty": 2,
+      "late_arrival_time_penalty": 5,
+      "compatibility_attributes": [
+        "A_order-24-dropoff"
+      ],
       "target_arrival_time": "2021-10-17T10:55:00-06:00",
       "id": "order-24-dropoff",
       "location": {

--- a/templates/routing-legacy/helper.go
+++ b/templates/routing-legacy/helper.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"github.com/nextmv-io/sdk/measure"
+	"github.com/nextmv-io/sdk/nextroute"
+	"github.com/nextmv-io/sdk/nextroute/common"
+	"github.com/nextmv-io/sdk/nextroute/schema"
+	"github.com/nextmv-io/sdk/route"
+	"github.com/twpayne/go-polyline"
+)
+
+func makeDistanceExpression(input schema.FleetInput) nextroute.DistanceExpression {
+	points := make([]measure.Point, len(input.Stops)+2*len(input.Vehicles))
+	for i, s := range input.Stops {
+		points[i] = measure.Point{
+			s.Position.Lon, s.Position.Lat,
+		}
+	}
+
+	counter := 0
+	for i := len(input.Stops); i < len(input.Stops); i += 2 {
+		if input.Vehicles[counter].Start != nil {
+			points[i] = measure.Point{
+				input.Vehicles[counter].Start.Lon, input.Vehicles[counter].Start.Lat,
+			}
+		}
+
+		if input.Vehicles[counter].End != nil {
+			points[i+1] = measure.Point{
+				input.Vehicles[counter].End.Lon, input.Vehicles[counter].End.Lat,
+			}
+		}
+		counter++
+	}
+
+	m := measure.HaversineByPoint()
+	mIndexed := measure.Indexed(m, points)
+
+	distanceMatrix := makeFloatMatrix(mIndexed, len(points))
+	distanceExpression := distanceExpression(&distanceMatrix)
+	return distanceExpression
+}
+
+// distanceExpression creates a distance expression for later use.
+func distanceExpression(distanceMatrix *[][]float64) nextroute.DistanceExpression {
+	distanceExpression := nextroute.NewHaversineExpression()
+	if distanceMatrix != nil {
+		distanceExpression = nextroute.NewDistanceExpression(
+			"travelDistance",
+			nextroute.NewMeasureByIndexExpression(measure.Matrix(*distanceMatrix)),
+			common.Meters,
+		)
+	}
+	return distanceExpression
+}
+
+type distanceData struct {
+	distance nextroute.DistanceExpression
+}
+
+// makeFloatMatrix is a helper function that takes a route.ByIndex and returns a
+// [][]float64.
+func makeFloatMatrix(matrix route.ByIndex, length int) [][]float64 {
+	out := make([][]float64, length)
+	for i := 0; i < length; i++ {
+		out[i] = make([]float64, length)
+		for j := 0; j < length; j++ {
+			out[i][j] = matrix.Cost(i, j)
+		}
+	}
+	return out
+}
+
+func haversinePolyline(p []measure.Point) (string, []string) {
+	if len(p) < 2 {
+		return "", []string{}
+	}
+	legs := make([]string, len(p))
+	allCoords := make([][]float64, len(p))
+	for i := 0; i < len(p); i++ {
+		current := p[i]
+		coord := []float64{
+			current[1], current[0],
+		}
+		allCoords[i] = coord
+		// the last stop does not have an individual leg
+		if i == len(p)-1 {
+			break
+		}
+		next := p[i+1]
+		coords := [][]float64{
+			{current[1], current[0]},
+			{next[1], next[0]},
+		}
+		leg := string(polyline.EncodeCoords(coords))
+		legs[i] = leg
+	}
+	routePolyline := string(polyline.EncodeCoords(allCoords))
+	return routePolyline, legs
+}

--- a/templates/routing-legacy/helper.go
+++ b/templates/routing-legacy/helper.go
@@ -9,7 +9,7 @@ import (
 	"github.com/twpayne/go-polyline"
 )
 
-func makeDistanceExpression(input schema.FleetInput) nextroute.DistanceExpression {
+func newDistanceExpression(input schema.FleetInput) nextroute.DistanceExpression {
 	points := make([]measure.Point, len(input.Stops)+2*len(input.Vehicles))
 	for i, s := range input.Stops {
 		points[i] = measure.Point{
@@ -36,7 +36,7 @@ func makeDistanceExpression(input schema.FleetInput) nextroute.DistanceExpressio
 	m := measure.HaversineByPoint()
 	mIndexed := measure.Indexed(m, points)
 
-	distanceMatrix := makeFloatMatrix(mIndexed, len(points))
+	distanceMatrix := newFloatMatrix(mIndexed, len(points))
 	distanceExpression := distanceExpression(&distanceMatrix)
 	return distanceExpression
 }
@@ -58,9 +58,9 @@ type distanceData struct {
 	distance nextroute.DistanceExpression
 }
 
-// makeFloatMatrix is a helper function that takes a route.ByIndex and returns a
+// newFloatMatrix is a helper function that takes a route.ByIndex and returns a
 // [][]float64.
-func makeFloatMatrix(matrix route.ByIndex, length int) [][]float64 {
+func newFloatMatrix(matrix route.ByIndex, length int) [][]float64 {
 	out := make([][]float64, length)
 	for i := 0; i < length; i++ {
 		out[i] = make([]float64, length)

--- a/templates/routing-legacy/helper.go
+++ b/templates/routing-legacy/helper.go
@@ -98,3 +98,16 @@ func haversinePolyline(p []measure.Point) (string, []string) {
 	routePolyline := string(polyline.EncodeCoords(allCoords))
 	return routePolyline, legs
 }
+
+// mapWithError maps a slice of type T to a slice of type R using the function f.
+func mapWithError[T any, R any](v []T, f func(T) (R, error)) ([]R, error) {
+	r := make([]R, len(v))
+	for idx, x := range v {
+		o, err := f(x)
+		if err != nil {
+			return r, err
+		}
+		r[idx] = o
+	}
+	return r, nil
+}

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -56,13 +56,12 @@ func solver(
 		}
 	}
 
-	distanceExpression := makeDistanceExpression(input)
-
 	model, err := factory.NewModel(nextrouteInput, options.Model)
 	if err != nil {
 		return FleetOutput{}, err
 	}
 
+	distanceExpression := makeDistanceExpression(input)
 	for _, v := range model.VehicleTypes() {
 		v.SetData(distanceData{
 			distance: distanceExpression,

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -3,10 +3,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log"
-	"os"
 	"time"
 
 	"github.com/nextmv-io/sdk"
@@ -46,9 +44,6 @@ func solver(
 	if err != nil {
 		panic(err)
 	}
-
-	b, err := json.Marshal(nextrouteInput)
-	os.WriteFile("test.json", b, 0644)
 
 	if input.Options != nil && input.Options.Solver != nil &&
 		input.Options.Solver.Limits != nil {

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -42,7 +42,7 @@ func solver(
 ) (FleetOutput, error) {
 	nextrouteInput, err := input.ToNextRoute()
 	if err != nil {
-		panic(err)
+		return FleetOutput{}, err
 	}
 
 	if input.Options != nil && input.Options.Solver != nil &&

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -38,7 +38,7 @@ func solver(
 ) (FleetOutput, error) {
 	nextrouteInput, err := input.ToNextRoute()
 	if err != nil {
-		panic(err)
+		return FleetOutput{}, err
 	}
 
 	if input.Options != nil && input.Options.Solver != nil &&
@@ -57,7 +57,7 @@ func solver(
 		return FleetOutput{}, err
 	}
 
-	distanceExpression := makeDistanceExpression(input)
+	distanceExpression := newDistanceExpression(input)
 	for _, v := range model.VehicleTypes() {
 		v.SetData(distanceData{
 			distance: distanceExpression,

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -3,8 +3,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
+	"os"
 	"time"
 
 	"github.com/nextmv-io/sdk"
@@ -44,6 +46,9 @@ func solver(
 	if err != nil {
 		panic(err)
 	}
+
+	b, err := json.Marshal(nextrouteInput)
+	os.WriteFile("test.json", b, 0644)
 
 	if input.Options != nil && input.Options.Solver != nil &&
 		input.Options.Solver.Limits != nil {

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -3,19 +3,23 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"time"
 
+	"github.com/nextmv-io/sdk"
+	"github.com/nextmv-io/sdk/alns"
 	"github.com/nextmv-io/sdk/nextroute"
+	"github.com/nextmv-io/sdk/nextroute/common"
 	"github.com/nextmv-io/sdk/nextroute/factory"
 	"github.com/nextmv-io/sdk/nextroute/schema"
 	"github.com/nextmv-io/sdk/run"
-	runSchema "github.com/nextmv-io/sdk/run/schema"
+	"github.com/nextmv-io/sdk/run/statistics"
 )
 
 func main() {
 	runner := run.CLI(solver,
-		run.InputValidate[run.CLIRunnerConfig, schema.FleetInput, options, runSchema.Output](
+		run.InputValidate[run.CLIRunnerConfig, schema.FleetInput, options, FleetOutput](
 			nil,
 		),
 	)
@@ -35,41 +39,150 @@ func solver(
 	ctx context.Context,
 	input schema.FleetInput,
 	options options,
-) (runSchema.Output, error) {
+) (FleetOutput, error) {
 	nextrouteInput, err := input.ToNextRoute()
 	if err != nil {
 		panic(err)
 	}
 
-	solveOptions := options.Solve
 	if input.Options != nil && input.Options.Solver != nil &&
 		input.Options.Solver.Limits != nil {
-		duration, err := time.ParseDuration(input.Options.Solver.Limits.Duration)
-		if err != nil {
-			return runSchema.Output{}, err
+		if input.Options.Solver.Limits.Duration != "" {
+			duration, err := time.ParseDuration(input.Options.Solver.Limits.Duration)
+			if err != nil {
+				return FleetOutput{}, err
+			}
+			options.Solve.Duration = duration
 		}
-
-		solveOptions.Duration = duration
 	}
+
+	distanceExpression := makeDistanceExpression(input)
 
 	model, err := factory.NewModel(nextrouteInput, options.Model)
 	if err != nil {
-		return runSchema.Output{}, err
+		return FleetOutput{}, err
+	}
+
+	for _, v := range model.VehicleTypes() {
+		v.SetData(distanceData{
+			distance: distanceExpression,
+		})
 	}
 
 	solver, err := nextroute.NewParallelSolver(model)
 	if err != nil {
-		return runSchema.Output{}, err
+		return FleetOutput{}, err
 	}
 
-	solutions, err := solver.Solve(ctx, solveOptions)
+	solutionsCount := "last"
+	runSolutions, err := run.ParseSolutions(solutionsCount)
 	if err != nil {
-		return runSchema.Output{}, err
+		return FleetOutput{}, err
 	}
-	last := solutions.Last()
 
-	output := factory.Format(ctx, options, solver, last)
-	output.Statistics.Result.Custom = factory.DefaultCustomResultStatistics(last)
+	solutions, err := solver.Solve(ctx, options.Solve)
+	if err != nil {
+		return FleetOutput{}, err
+	}
+
+	// Last solution == 1, all solutions == 0
+	if runSolutions == 1 {
+		last := solutions.Last()
+		output, err := format(ctx, options.Solve.Duration, solver, ToFleetSolutionOutput, last)
+		if err != nil {
+			return output, err
+		}
+		return output, nil
+	}
+
+	solutionArray := make([]nextroute.Solution, 0)
+	for s := range solutions {
+		solutionArray = append(solutionArray, s)
+	}
+	output, err := format(ctx, options.Solve.Duration, solver, ToFleetSolutionOutput, solutionArray...)
+	if err != nil {
+		return output, err
+	}
+	return output, nil
+}
+
+func format(
+	ctx context.Context,
+	duration time.Duration,
+	progressioner alns.Progressioner,
+	toSolutionOutputFn func(nextroute.Solution) (any, error),
+	solutions ...nextroute.Solution,
+) (FleetOutput, error) {
+	mappedSolutions, err := MapWithError(solutions, toSolutionOutputFn)
+	if err != nil {
+		return FleetOutput{}, err
+	}
+
+	output := FleetOutput{
+		Solutions: mappedSolutions,
+		Options: schema.Options{
+			Solver: &schema.SolverOptions{
+				Limits: &schema.Limits{
+					Duration: duration.String(),
+				},
+			},
+		},
+		Hop: struct {
+			Version string "json:\"version\""
+		}{
+			Version: sdk.VERSION,
+		},
+	}
+
+	startTime := time.Time{}
+	if start, ok := ctx.Value(run.Start).(time.Time); ok {
+		startTime = start
+	}
+
+	progressionValues := progressioner.Progression()
+
+	if len(progressionValues) == 0 {
+		return output, errors.New("no solution values or elapsed time values found")
+	}
+
+	seriesData := common.Map(
+		progressionValues,
+		func(progressionEntry alns.ProgressionEntry) statistics.DataPoint {
+			return statistics.DataPoint{
+				X: statistics.Float64(progressionEntry.ElapsedSeconds),
+				Y: statistics.Float64(progressionEntry.Value),
+			}
+		},
+	)
+
+	if len(output.Solutions) == 1 {
+		seriesData = seriesData[len(seriesData)-1:]
+	}
+
+	if len(output.Solutions) != len(seriesData) {
+		return output, errors.New("more or less solution values than solutions found")
+	}
+	for idx, data := range seriesData {
+		if _, ok := output.Solutions[idx].(FleetState); ok {
+			output.Statistics.Time.Start = startTime
+			output.Statistics.Value = int(data.Y)
+			output.Statistics.Time.ElapsedSeconds = float64(data.X)
+			output.Statistics.Time.Elapsed = time.Duration(data.X * statistics.Float64(time.Second)).String()
+		}
+	}
 
 	return output, nil
+}
+
+// MapWithError maps a slice of type T to a slice of type R using the function f.
+func MapWithError[T any, R any](v []T, f func(T) (R, error)) ([]R, error) {
+	r := make([]R, len(v))
+	for idx, x := range v {
+		o, err := f(x)
+		if err != nil {
+			return r, err
+		}
+		r[idx] = o
+	}
+	return r, nil
 }

--- a/templates/routing-legacy/main.go
+++ b/templates/routing-legacy/main.go
@@ -3,8 +3,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
+	"os"
 	"time"
 
 	"github.com/nextmv-io/sdk"
@@ -42,8 +44,11 @@ func solver(
 ) (FleetOutput, error) {
 	nextrouteInput, err := input.ToNextRoute()
 	if err != nil {
-		return FleetOutput{}, err
+		panic(err)
 	}
+
+	b, err := json.Marshal(nextrouteInput)
+	os.WriteFile("test.json", b, 0644)
 
 	if input.Options != nil && input.Options.Solver != nil &&
 		input.Options.Solver.Limits != nil {
@@ -73,19 +78,13 @@ func solver(
 		return FleetOutput{}, err
 	}
 
-	solutionsCount := "last"
-	runSolutions, err := run.ParseSolutions(solutionsCount)
-	if err != nil {
-		return FleetOutput{}, err
-	}
-
 	solutions, err := solver.Solve(ctx, options.Solve)
 	if err != nil {
 		return FleetOutput{}, err
 	}
 
-	// Last solution == 1, all solutions == 0
-	if runSolutions == 1 {
+	runSolutions := run.Last
+	if runSolutions == run.Last {
 		last := solutions.Last()
 		output, err := format(ctx, options.Solve.Duration, solver, ToFleetSolutionOutput, last)
 		if err != nil {

--- a/templates/routing-legacy/output.go
+++ b/templates/routing-legacy/output.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/nextmv-io/sdk/measure"
+	"github.com/nextmv-io/sdk/nextroute"
+	"github.com/nextmv-io/sdk/nextroute/common"
+	"github.com/nextmv-io/sdk/nextroute/schema"
+)
+
+// FleetOutput is the root output structure.
+// DEPRECATION NOTICE: this part of the API is deprecated and is no longer
+// maintained. It will be deleted soon. Please use [SolutionOutput] and it's
+// entities instead.
+type FleetOutput struct {
+	Hop struct {
+		Version string `json:"version"`
+	} `json:"hop"`
+	Options    schema.Options `json:"options"`
+	Solutions  []any          `json:"solutions"`
+	Statistics Statistics     `json:"statistics"`
+}
+
+// FleetState is the solution output structure.
+// DEPRECATION NOTICE: this part of the API is deprecated and is no longer
+// maintained. It will be deleted soon. Please use [SolutionOutput] and it's
+// entities instead.
+type FleetState struct {
+	Vehicles   []FleetOutputVehicle `json:"vehicles"`
+	Unassigned []FleetOutputStop    `json:"unassigned"`
+	Summary    FleetOutputSummary   `json:"value_summary"` //nolint:tagliatelle
+}
+
+// Statistics adds run stats to the output.
+type Statistics struct {
+	Time  Time `json:"time"`
+	Value int  `json:"value"`
+}
+
+// Time holds runtime information.
+type Time struct {
+	Start          time.Time `json:"start"`
+	Elapsed        string    `json:"elapsed"`
+	ElapsedSeconds float64   `json:"elapsed_seconds"`
+}
+
+// FleetOutputSummary contains a breakdown of the objective value.
+// DEPRECATION NOTICE: this part of the API is deprecated and is no longer
+// maintained. It will be deleted soon. Please use [SolutionOutput] and it's
+// entities instead.
+type FleetOutputSummary struct {
+	Value                           float64 `json:"value"`
+	TotalTravelDistance             float64 `json:"total_travel_distance"`
+	TotalTravelTime                 int     `json:"total_travel_time"`
+	TotalEarlinessPenalty           *int    `json:"total_earliness_penalty,omitempty"`
+	TotalLatenessPenalty            *int    `json:"total_lateness_penalty,omitempty"`
+	TotalUnassignedPenalty          float64 `json:"total_unassigned_penalty"`
+	TotalVehicleInitializationCosts int     `json:"total_vehicle_initialization_costs"`
+}
+
+// FleetOutputVehicle contains the route for one vehicle.
+// DEPRECATION NOTICE: this part of the API is deprecated and is no longer
+// maintained. It will be deleted soon. Please use [SolutionOutput] and it's
+// entities instead.
+type FleetOutputVehicle struct {
+	ID                         string            `json:"id"`
+	Value                      int               `json:"value"`
+	TravelDistance             float64           `json:"travel_distance"`
+	TravelTime                 int               `json:"travel_time"`
+	EarlinessPenalty           *int              `json:"earliness_penalty,omitempty"`
+	LatenessPenalty            *int              `json:"lateness_penalty,omitempty"`
+	VehicleInitializationCosts int               `json:"vehicle_initialization_costs"`
+	Route                      []FleetOutputStop `json:"route,omitempty"`
+	Polyline                   string            `json:"polyline,omitempty"`
+}
+
+// FleetOutputStop contains all data of a stop.
+// DEPRECATION NOTICE: this part of the API is deprecated and is no longer
+// maintained. It will be deleted soon. Please use [SolutionOutput] and it's
+// entities instead.
+type FleetOutputStop struct {
+	ID               string     `json:"id"`
+	Lon              float64    `json:"lon"`
+	Lat              float64    `json:"lat"`
+	Distance         *float64   `json:"distance,omitempty"`
+	ETA              *time.Time `json:"eta,omitempty"`
+	ETS              *time.Time `json:"ets,omitempty"`
+	ETD              *time.Time `json:"etd,omitempty"`
+	EarlinessPenalty *int       `json:"earliness_penalty,omitempty"`
+	LatenessPenalty  *int       `json:"lateness_penalty,omitempty"`
+	Polyline         string     `json:"polyline,omitempty"`
+}
+
+// ToFleetSolutionOutput is a transformation function to create a legacy fleet
+// output format.
+func ToFleetSolutionOutput(solution nextroute.Solution) (any, error) {
+	fleetOutputVehicles, err := MapWithError(solution.Vehicles(), toFleetVehicleOutput)
+	if err != nil {
+		return FleetState{}, err
+	}
+
+	return FleetState{
+		Unassigned: common.MapSlice(
+			solution.UnPlannedPlanUnits().SolutionPlanUnits(),
+			func(solutionPlanUnit nextroute.SolutionPlanUnit) []FleetOutputStop {
+				return common.Map(
+					solutionPlanUnit.SolutionStops(),
+					func(solutionStop nextroute.SolutionStop) FleetOutputStop {
+						return toFleetStopOutput(solutionStop.ModelStop())
+					},
+				)
+			},
+		),
+		Vehicles: fleetOutputVehicles,
+		Summary:  toFleetObjectiveOutput(solution),
+	}, nil
+}
+
+func toFleetStopOutput(modelStop nextroute.ModelStop) FleetOutputStop {
+	return FleetOutputStop{
+		ID:  modelStop.ID(),
+		Lon: modelStop.Location().Longitude(),
+		Lat: modelStop.Location().Latitude(),
+	}
+}
+
+func toPlannedStopOutput(solutionStop nextroute.SolutionStop) FleetOutputStop {
+	timezoneLocation := solutionStop.
+		Vehicle().
+		ModelVehicle().
+		Start().
+		Location()
+
+	stop := toFleetStopOutput(solutionStop.ModelStop())
+
+	plannedStopOutput := FleetOutputStop{
+		ID:  stop.ID,
+		Lon: stop.Lon,
+		Lat: stop.Lat,
+	}
+
+	arrival := solutionStop.Arrival().In(timezoneLocation)
+	end := solutionStop.End().In(timezoneLocation)
+	start := solutionStop.Start().In(timezoneLocation)
+
+	if solutionStop.Vehicle().First().Start() !=
+		solutionStop.Vehicle().ModelVehicle().Model().Epoch() {
+		plannedStopOutput.ETA = &arrival
+		plannedStopOutput.ETD = &end
+		plannedStopOutput.ETS = &start
+	}
+
+	initPenalty := 0
+	plannedStopOutput.EarlinessPenalty = &initPenalty
+	plannedStopOutput.LatenessPenalty = &initPenalty
+	if inputStop, ok := solutionStop.ModelStop().Data().(schema.Stop); ok {
+		if inputStop.EarlyArrivalTimePenalty != nil && inputStop.TargetArrivalTime != nil {
+			penaltyValue := int(*inputStop.EarlyArrivalTimePenalty)
+			duration := int(math.Max(inputStop.TargetArrivalTime.Sub(arrival).Seconds(), 0.0))
+			penalty := penaltyValue * duration
+			plannedStopOutput.EarlinessPenalty = &penalty
+		}
+
+		if inputStop.LateArrivalTimePenalty != nil && inputStop.TargetArrivalTime != nil {
+			penaltyValue := int(*inputStop.LateArrivalTimePenalty)
+			duration := int(math.Max(arrival.Sub(*inputStop.TargetArrivalTime).Seconds(), 0.0))
+			penalty := penaltyValue * duration
+			plannedStopOutput.LatenessPenalty = &penalty
+		}
+	}
+
+	if data, ok := solutionStop.Vehicle().ModelVehicle().VehicleType().Data().(distanceData); ok {
+		distance := 0.0
+		if solutionStop.Previous().ModelStop().Location().IsValid() &&
+			solutionStop.ModelStop().Location().IsValid() {
+			distance = data.distance.Value(
+				solutionStop.Vehicle().ModelVehicle().VehicleType(),
+				solutionStop.Previous().ModelStop(),
+				solutionStop.ModelStop(),
+			)
+		}
+		plannedStopOutput.Distance = &distance
+	}
+
+	return plannedStopOutput
+}
+
+func toFleetVehicleOutput(vehicle nextroute.SolutionVehicle) (FleetOutputVehicle, error) {
+	solutionStops := common.Filter(
+		vehicle.SolutionStops(),
+		func(solutionStop nextroute.SolutionStop) bool {
+			return solutionStop.ModelStop().Location().IsValid()
+		},
+	)
+
+	route := common.Map(
+		solutionStops,
+		toPlannedStopOutput,
+	)
+
+	earliness := 0
+	lateness := 0
+	routeTravelDistance := 0.0
+	polylinePoints := []measure.Point{}
+	for idx, stop := range route {
+		if stop.EarlinessPenalty != nil {
+			earliness += *stop.EarlinessPenalty
+		}
+		if stop.LatenessPenalty != nil {
+			lateness += *stop.LatenessPenalty
+		}
+		routeTravelDistance += *stop.Distance
+		route[idx].Distance = &routeTravelDistance
+
+		polylinePoints = append(polylinePoints, measure.Point{
+			stop.Lon, stop.Lat,
+		})
+	}
+
+	polyline, legs := haversinePolyline(polylinePoints)
+
+	for i := range route {
+		if i < len(legs) {
+			route[i].Polyline = legs[i]
+		}
+	}
+
+	initCosts := 0
+	if inputVehicle, ok := vehicle.ModelVehicle().Data().(schema.Vehicle); ok {
+		if len(route) > 0 && inputVehicle.ActivationPenalty != nil {
+			initCosts = *inputVehicle.ActivationPenalty
+		}
+	}
+
+	vehicleOutput := FleetOutputVehicle{
+		ID:                         vehicle.ModelVehicle().ID(),
+		Route:                      route,
+		TravelTime:                 int(vehicle.Duration().Seconds()),
+		TravelDistance:             routeTravelDistance,
+		Value:                      int(vehicle.Duration().Seconds()) + earliness + lateness,
+		EarlinessPenalty:           &earliness,
+		LatenessPenalty:            &lateness,
+		VehicleInitializationCosts: initCosts,
+		Polyline:                   polyline,
+	}
+
+	return vehicleOutput, nil
+}
+
+func toFleetObjectiveOutput(solution nextroute.Solution) FleetOutputSummary {
+	earlinessPenalty := 0
+	latenessPenatly := 0
+	unassignedPenalty := 0.0
+	travelTime := 0.0
+	initCosts := 0
+
+	for _, t := range solution.Model().Objective().Terms() {
+		switch fmt.Sprintf("%v", t.Objective()) {
+		case "early_arrival_penalty":
+			earlinessPenalty = int(solution.ObjectiveValue(t.Objective()))
+		case "unplanned_penalty":
+			unassignedPenalty = solution.ObjectiveValue(t.Objective())
+		case "late_arrival_penalty":
+			latenessPenatly = int(solution.ObjectiveValue(t.Objective()))
+		case "vehicles_duration":
+			travelTime = solution.ObjectiveValue(t.Objective())
+		case "vehicle_activation_penalty":
+			initCosts = int(solution.ObjectiveValue(t.Objective()))
+		}
+	}
+
+	travelDistance := 0.0
+	for _, v := range solution.Vehicles() {
+		if data, ok := v.ModelVehicle().VehicleType().Data().(distanceData); ok {
+			for _, s := range v.SolutionStops() {
+				distance := data.distance.Value(
+					s.Vehicle().ModelVehicle().VehicleType(),
+					s.Previous().ModelStop(),
+					s.ModelStop(),
+				)
+				travelDistance += distance
+			}
+		}
+	}
+
+	return FleetOutputSummary{
+		Value:                           solution.ObjectiveValue(solution.Model().Objective()),
+		TotalTravelTime:                 int(travelTime),
+		TotalEarlinessPenalty:           &earlinessPenalty,
+		TotalLatenessPenalty:            &latenessPenatly,
+		TotalUnassignedPenalty:          unassignedPenalty,
+		TotalTravelDistance:             travelDistance,
+		TotalVehicleInitializationCosts: initCosts,
+	}
+}

--- a/templates/routing-legacy/output.go
+++ b/templates/routing-legacy/output.go
@@ -106,12 +106,15 @@ func ToFleetSolutionOutput(solution nextroute.Solution) (any, error) {
 		Unassigned: common.MapSlice(
 			solution.UnPlannedPlanUnits().SolutionPlanUnits(),
 			func(solutionPlanUnit nextroute.SolutionPlanUnit) []FleetOutputStop {
-				return common.Map(
-					solutionPlanUnit.SolutionStops(),
-					func(solutionStop nextroute.SolutionStop) FleetOutputStop {
-						return toFleetStopOutput(solutionStop.ModelStop())
-					},
-				)
+				if solutionPlanStopsUnit, ok := solutionPlanUnit.(nextroute.SolutionPlanStopsUnit); ok {
+					return common.Map(
+						solutionPlanStopsUnit.SolutionStops(),
+						func(solutionStop nextroute.SolutionStop) FleetOutputStop {
+							return toFleetStopOutput(solutionStop.ModelStop())
+						},
+					)
+				}
+				return []FleetOutputStop{}
 			},
 		),
 		Vehicles: fleetOutputVehicles,

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -21,6 +21,13 @@ var (
 	// RoutingLegacyMain is the main.go file in the routing-legacy template.
 	//go:embed routing-legacy/main.go
 	RoutingLegacyMain string
+	// RoutingLegacyHelper is file with helper functions in the routing-legacy
+	// template.
+	//go:embed routing-legacy/helper.go
+	RoutingLegacyHelper string
+	// RoutingLegacyOutput is the output.go file in the routing-legacy template.
+	//go:embed routing-legacy/output.go
+	RoutingLegacyOutput string
 	// RoutingLegacyInput is the input.json file in the routing-legacy template.
 	//go:embed routing-legacy/input.json
 	RoutingLegacyInput string


### PR DESCRIPTION
# Description

Adds legacy output to the legacy-routing template and fixes some additional stuff.

## Changes

* legacy-routing/main.go
* legacy-routing/output.go
* legacy-routing/helper.go
* fleet.go
* fleet_defaults.go