### PR TITLE
Do not ommit 0 values for custom statistics

### DIFF
--- a/nextroute/schema/output.go
+++ b/nextroute/schema/output.go
@@ -63,26 +63,26 @@ type ObjectiveOutput struct {
 type CustomResultStatistics struct {
 	// ActivatedVehicles is the number of vehicles that were used in the
 	// solution.
-	ActivatedVehicles int `json:"activated_vehicles,omitempty"`
+	ActivatedVehicles int `json:"activated_vehicles"`
 	// UnplannedStops is the number of stops that were not planned in the
 	// solution.
-	UnplannedStops int `json:"unplanned_stops,omitempty"`
+	UnplannedStops int `json:"unplanned_stops"`
 	// MaxTravelDuration is the maximum travel duration of a vehicle in the
 	// solution.
-	MaxTravelDuration int `json:"max_travel_duration,omitempty"`
+	MaxTravelDuration int `json:"max_travel_duration"`
 	// MaxDuration is the maximum duration of a vehicle (including waiting
 	// times) in the solution.
-	MaxDuration int `json:"max_duration,omitempty"`
+	MaxDuration int `json:"max_duration"`
 	// MinTravelDuration is the minimum travel duration of a vehicle in the
 	// solution, excluding vehicles that were not used.
-	MinTravelDuration int `json:"min_travel_duration,omitempty"`
+	MinTravelDuration int `json:"min_travel_duration"`
 	// MinDuration is the minimum duration of a vehicle (including waiting
 	// times) in the solution, excluding vehicles that were not used.
-	MinDuration int `json:"min_duration,omitempty"`
+	MinDuration int `json:"min_duration"`
 	// MaxStopsInRoute is the maximum number of stops in a vehicle's route in
 	// the solution. The start and end stops of the vehicle are not considered.
-	MaxStopsInVehicle int `json:"max_stops_in_vehicle,omitempty"`
+	MaxStopsInVehicle int `json:"max_stops_in_vehicle"`
 	// MinStopsInRoute is the minimum number of stops in a vehicle's route in
 	// the solution. The start and end stops of the vehicle are not considered.
-	MinStopsInVehicle int `json:"min_stops_in_vehicle,omitempty"`
+	MinStopsInVehicle int `json:"min_stops_in_vehicle"`
 }


### PR DESCRIPTION
This outputs zero values for all routing specific custom statistics. 0 is a valid information for all of these metrics. Omitting them implies these values are missing.