### PR TITLE
feature/eng-3875-fix-default-0-value-for-unassigned-penalty

### DIFF
--- a/nextroute/schema/fleet_defaults.go
+++ b/nextroute/schema/fleet_defaults.go
@@ -85,7 +85,6 @@ func (fleetInput *FleetInput) applyVehicleDefaults() {
 // and stops not explicitly defined.
 func (fleetInput *FleetInput) applyStopDefaults() {
 	// Specify some defaults for missing values
-	unassignedPenalty := 0
 	quantity := 0
 	stopDuration := 0
 	stopCompatibilities := []string{}
@@ -98,8 +97,6 @@ func (fleetInput *FleetInput) applyStopDefaults() {
 		if fleetInput.Stops[s].UnassignedPenalty == nil {
 			if stopDefaults && fleetInput.Defaults.Stops.UnassignedPenalty != nil {
 				fleetInput.Stops[s].UnassignedPenalty = fleetInput.Defaults.Stops.UnassignedPenalty
-			} else {
-				fleetInput.Stops[s].UnassignedPenalty = &unassignedPenalty
 			}
 		}
 


### PR DESCRIPTION
# Description

This PR leaves the unassigned penalty set to `nil` instead of setting it to `0` for the `legacy-routing` template.