### PR TITLE
updates default for min stops to 1

### DIFF
--- a/nextroute/factory/model.go
+++ b/nextroute/factory/model.go
@@ -43,7 +43,7 @@ type Options struct {
 		} `json:"enable"`
 	} `json:"constraints"`
 	Objectives struct {
-		MinStops                 float64 `json:"min_stops" usage:"factor to weigh the min stops objective" default:"0.0"`
+		MinStops                 float64 `json:"min_stops" usage:"factor to weigh the min stops objective" default:"1.0"`
 		EarlyArrivalPenalty      float64 `json:"early_arrival_penalty" usage:"factor to weigh the early arrival objective" default:"1.0"`
 		LateArrivalPenalty       float64 `json:"late_arrival_penalty" usage:"factor to weigh the late arrival objective" default:"1.0"`
 		VehicleActivationPenalty float64 `json:"vehicle_activation_penalty" usage:"factor to weigh the vehicle activation objective" default:"1.0"`


### PR DESCRIPTION
The min stops objective was previously defaulting to 0 so when passing in min_stops and min_stops_penalty in the input, we weren't activating this term in the objective. This sets the default value to 1 so it will always activate when passed through the input. 