### PR TITLE
Fixes typo in struct tag

### DIFF
--- a/nextroute/schema/input.go
+++ b/nextroute/schema/input.go
@@ -208,7 +208,7 @@ type Stop struct {
 // Location represents a geographical location.
 type Location struct {
 	// Lon longitude of the location.
-	Lon float64 `json:"lon" minimum:"-180" maximum:"180`
+	Lon float64 `json:"lon" minimum:"-180" maximum:"180"`
 	// Lat latitude of the location.
 	Lat float64 `json:"lat" minimum:"-90" maximum:"90"`
 }


### PR DESCRIPTION
# Description

Fixes a typo in the tags of the `Lon` input field.

## Changes

- Fixes typo in nextroute input struct tags