### PR TITLE
Updated workflow node version

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.17.1
+          node-version: 18.8
 
       - name: install prettier
         run: npm install prettier@v2.7.1 --global


### PR DESCRIPTION
# Description

Updates workflow node version.

## Changes

- `.github/workflows/json-lint.yml`
    - Updates node version
    
## Backwards compatibility

This change should not impact any of the SDK code itself- the only place we use node in this repo is to lint JSON. We probably still don't want the version to be way out of EOL for that though.

## Testing

Workflows seem to run fine still.