### PR TITLE
Introduce initial solution construction heuristic for stop groups.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -226,6 +226,10 @@ issues:
       linters:
         - gosec
       text: G404
+    # Complexity is fine here because of the nature of the code
+    - path: nextroute/common/boundingbox_test\.go
+      linters:
+        - gocyclo
     - path: nextroute/common/utils\.go
       linters:
         - gomodguard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -202,7 +202,10 @@ issues:
     - path: nextroute/factory/model\.go
       linters:
         - lll
-
+    # Deactivate line length in construction.go because of go tags
+    - path: nextroute/factory/construction\.go
+      linters:
+        - lll
     # Tag should be 'measure' in both cases ByPoint and ByIndex
     - path: route/load\.go
       linters:

--- a/nextroute/common/boundingbox.go
+++ b/nextroute/common/boundingbox.go
@@ -1,6 +1,6 @@
 package common
 
-// BoundingBox contains information about a box
+// BoundingBox contains information about a box.
 type BoundingBox interface {
 	// Maximum returns the maximum location of the bounding box. The right
 	// lower corner of the bounding box.
@@ -70,6 +70,7 @@ func Union(a, b BoundingBox) BoundingBox {
 	}
 }
 
+// NewInvalidBoundingBox returns an invalid bounding box.
 func NewInvalidBoundingBox() BoundingBox {
 	return boundingBox{
 		maximum: NewInvalidLocation(),
@@ -77,6 +78,7 @@ func NewInvalidBoundingBox() BoundingBox {
 	}
 }
 
+// NewBoundingBox returns a bounding box for the given locations.
 func NewBoundingBox(locations Locations) BoundingBox {
 	if len(locations) == 0 || !locations[0].IsValid() {
 		return NewInvalidBoundingBox()

--- a/nextroute/common/boundingbox.go
+++ b/nextroute/common/boundingbox.go
@@ -1,0 +1,155 @@
+package common
+
+// BoundingBox contains information about a box
+type BoundingBox interface {
+	// Maximum returns the maximum location of the bounding box. The right
+	// lower corner of the bounding box.
+	Maximum() Location
+	// Minimum returns the minimum location of the bounding box. The left
+	// upper corner of the bounding box.
+	Minimum() Location
+	// IsValid returns true if the bounding box is valid. A bounding box is
+	// valid if the maximum location is greater than the minimum location.
+	IsValid() bool
+	// Width returns the width of the box.
+	Width() Distance
+	// Height returns the height of the box.
+	Height() Distance
+}
+
+// Intersection returns the intersection of the two bounding boxes.
+func Intersection(a, b BoundingBox) BoundingBox {
+	if !a.IsValid() || !b.IsValid() {
+		return NewInvalidBoundingBox()
+	}
+	maximum := a.Maximum()
+	minimum := a.Minimum()
+	if b.Maximum().Longitude() < maximum.Longitude() {
+		maximum = b.Maximum()
+	}
+	if b.Maximum().Latitude() < maximum.Latitude() {
+		maximum = b.Maximum()
+	}
+	if b.Minimum().Longitude() > minimum.Longitude() {
+		minimum = b.Minimum()
+	}
+	if b.Minimum().Latitude() > minimum.Latitude() {
+		minimum = b.Minimum()
+	}
+	return boundingBox{
+		maximum: maximum,
+		minimum: minimum,
+	}
+}
+
+// Union returns the union of the two bounding boxes.
+func Union(a, b BoundingBox) BoundingBox {
+	if !a.IsValid() {
+		return b
+	}
+	if !b.IsValid() {
+		return a
+	}
+	maximum := a.Maximum()
+	minimum := a.Minimum()
+	if b.Maximum().Longitude() > maximum.Longitude() {
+		maximum = b.Maximum()
+	}
+	if b.Maximum().Latitude() > maximum.Latitude() {
+		maximum = b.Maximum()
+	}
+	if b.Minimum().Longitude() < minimum.Longitude() {
+		minimum = b.Minimum()
+	}
+	if b.Minimum().Latitude() < minimum.Latitude() {
+		minimum = b.Minimum()
+	}
+	return boundingBox{
+		maximum: maximum,
+		minimum: minimum,
+	}
+}
+
+func NewInvalidBoundingBox() BoundingBox {
+	return boundingBox{
+		maximum: NewInvalidLocation(),
+		minimum: NewInvalidLocation(),
+	}
+}
+
+func NewBoundingBox(locations Locations) BoundingBox {
+	if len(locations) == 0 || !locations[0].IsValid() {
+		return NewInvalidBoundingBox()
+	}
+
+	minLatitude := locations[0].Latitude()
+	maxLatitude := locations[0].Latitude()
+	minLongitude := locations[0].Longitude()
+	maxLongitude := locations[0].Longitude()
+
+	for idx := 1; idx < len(locations); idx++ {
+		if !locations[idx].IsValid() {
+			return NewInvalidBoundingBox()
+		}
+		latitude := locations[idx].Latitude()
+		longitude := locations[idx].Longitude()
+		if minLatitude > latitude {
+			minLatitude = latitude
+		}
+		if maxLatitude < latitude {
+			maxLatitude = latitude
+		}
+		if minLongitude > longitude {
+			minLongitude = longitude
+		}
+		if maxLongitude < longitude {
+			maxLongitude = longitude
+		}
+	}
+	maxLocation, _ := NewLocation(maxLongitude, maxLatitude)
+	minLocation, _ := NewLocation(minLongitude, minLatitude)
+	return boundingBox{
+		maximum: maxLocation,
+		minimum: minLocation,
+	}
+}
+
+type boundingBox struct {
+	maximum Location
+	minimum Location
+}
+
+func (b boundingBox) Width() Distance {
+	if !b.IsValid() {
+		return NewDistance(0.0, Meters)
+	}
+	leftUpper, _ := NewLocation(b.minimum.Longitude(), b.minimum.Latitude())
+	rightUpper, _ := NewLocation(b.maximum.Longitude(), b.minimum.Latitude())
+	width, _ := Haversine(leftUpper, rightUpper)
+	return width
+}
+
+func (b boundingBox) Height() Distance {
+	if !b.IsValid() {
+		return NewDistance(0.0, Meters)
+	}
+	leftUpper, _ := NewLocation(b.minimum.Longitude(), b.minimum.Latitude())
+	leftLower, _ := NewLocation(b.minimum.Longitude(), b.maximum.Latitude())
+	height, _ := Haversine(leftUpper, leftLower)
+	return height
+}
+
+func (b boundingBox) IsValid() bool {
+	return b.maximum.IsValid() &&
+		b.minimum.IsValid() &&
+		b.maximum.Longitude() >= b.minimum.Longitude() &&
+		b.maximum.Latitude() >= b.minimum.Latitude()
+}
+
+func (b boundingBox) Maximum() Location {
+	return b.maximum
+}
+
+func (b boundingBox) Minimum() Location {
+	return b.minimum
+}

--- a/nextroute/common/boundingbox.go
+++ b/nextroute/common/boundingbox.go
@@ -17,59 +17,6 @@ type BoundingBox interface {
 	Height() Distance
 }
 
-// Intersection returns the intersection of the two bounding boxes.
-func Intersection(a, b BoundingBox) BoundingBox {
-	if !a.IsValid() || !b.IsValid() {
-		return NewInvalidBoundingBox()
-	}
-	maximum := a.Maximum()
-	minimum := a.Minimum()
-	if b.Maximum().Longitude() < maximum.Longitude() {
-		maximum = b.Maximum()
-	}
-	if b.Maximum().Latitude() < maximum.Latitude() {
-		maximum = b.Maximum()
-	}
-	if b.Minimum().Longitude() > minimum.Longitude() {
-		minimum = b.Minimum()
-	}
-	if b.Minimum().Latitude() > minimum.Latitude() {
-		minimum = b.Minimum()
-	}
-	return boundingBox{
-		maximum: maximum,
-		minimum: minimum,
-	}
-}
-
-// Union returns the union of the two bounding boxes.
-func Union(a, b BoundingBox) BoundingBox {
-	if !a.IsValid() {
-		return b
-	}
-	if !b.IsValid() {
-		return a
-	}
-	maximum := a.Maximum()
-	minimum := a.Minimum()
-	if b.Maximum().Longitude() > maximum.Longitude() {
-		maximum = b.Maximum()
-	}
-	if b.Maximum().Latitude() > maximum.Latitude() {
-		maximum = b.Maximum()
-	}
-	if b.Minimum().Longitude() < minimum.Longitude() {
-		minimum = b.Minimum()
-	}
-	if b.Minimum().Latitude() < minimum.Latitude() {
-		minimum = b.Minimum()
-	}
-	return boundingBox{
-		maximum: maximum,
-		minimum: minimum,
-	}
-}
-
 // NewInvalidBoundingBox returns an invalid bounding box.
 func NewInvalidBoundingBox() BoundingBox {
 	return boundingBox{

--- a/nextroute/common/boundingbox_test.go
+++ b/nextroute/common/boundingbox_test.go
@@ -1,8 +1,9 @@
 package common_test
 
 import (
-	"github.com/nextmv-io/sdk/nextroute/common"
 	"testing"
+
+	"github.com/nextmv-io/sdk/nextroute/common"
 )
 
 func TestBoundingBox(t *testing.T) {
@@ -79,6 +80,7 @@ func TestBoundingBox(t *testing.T) {
 	if !common.WithinTolerance(box.Height().Value(common.Meters), 111194.92664455874, 0.000001) {
 		t.Errorf("Expected height 111194.92664455874, got %v", box.Height().Value(common.Meters))
 	}
+
 	location3, _ := common.NewLocation(-2, 2)
 	location4, _ := common.NewLocation(2, -2)
 

--- a/nextroute/common/boundingbox_test.go
+++ b/nextroute/common/boundingbox_test.go
@@ -1,0 +1,114 @@
+package common_test
+
+import (
+	"github.com/nextmv-io/sdk/nextroute/common"
+	"testing"
+)
+
+func TestBoundingBox(t *testing.T) {
+	invalidBox := common.NewInvalidBoundingBox()
+	if invalidBox.IsValid() {
+		t.Errorf("Expected invalid bounding box")
+	}
+	if invalidBox.Maximum().IsValid() {
+		t.Errorf("Expected invalid maximum for invalid bounding box")
+	}
+	if invalidBox.Minimum().IsValid() {
+		t.Errorf("Expected invalid minimum for invalid bounding box")
+	}
+	location, _ := common.NewLocation(0, 0)
+
+	box := common.NewBoundingBox(common.Locations{location})
+
+	if !box.IsValid() {
+		t.Errorf("Expected valid bounding box")
+	}
+	if !box.Maximum().IsValid() {
+		t.Errorf("Expected valid maximum for valid bounding box")
+	}
+	if !box.Minimum().IsValid() {
+		t.Errorf("Expected valid minimum for valid bounding box")
+	}
+	if box.Maximum().Latitude() != 0 {
+		t.Errorf("Expected maximum latitude 0, got %v", box.Maximum().Latitude())
+	}
+	if box.Maximum().Longitude() != 0 {
+		t.Errorf("Expected maximum longitude 0, got %v", box.Maximum().Longitude())
+	}
+	if box.Minimum().Latitude() != 0 {
+		t.Errorf("Expected minimum latitude 0, got %v", box.Minimum().Latitude())
+	}
+	if box.Minimum().Longitude() != 0 {
+		t.Errorf("Expected minimum longitude 0, got %v", box.Minimum().Longitude())
+	}
+	if box.Width().Value(common.Meters) != 0 {
+		t.Errorf("Expected width 0, got %v", box.Width())
+	}
+	if box.Height().Value(common.Meters) != 0 {
+		t.Errorf("Expected height 0, got %v", box.Height())
+	}
+
+	location2, _ := common.NewLocation(1, 1)
+
+	box = common.NewBoundingBox(common.Locations{location, location2})
+
+	if !box.IsValid() {
+		t.Errorf("Expected valid bounding box")
+	}
+	if !box.Maximum().IsValid() {
+		t.Errorf("Expected valid maximum for valid bounding box")
+	}
+	if !box.Minimum().IsValid() {
+		t.Errorf("Expected valid minimum for valid bounding box")
+	}
+	if box.Maximum().Latitude() != 1 {
+		t.Errorf("Expected maximum latitude 1, got %v", box.Maximum().Latitude())
+	}
+	if box.Maximum().Longitude() != 1 {
+		t.Errorf("Expected maximum longitude 1, got %v", box.Maximum().Longitude())
+	}
+	if box.Minimum().Latitude() != 0 {
+		t.Errorf("Expected minimum latitude 0, got %v", box.Minimum().Latitude())
+	}
+	if box.Minimum().Longitude() != 0 {
+		t.Errorf("Expected minimum longitude 0, got %v", box.Minimum().Longitude())
+	}
+	if !common.WithinTolerance(box.Width().Value(common.Meters), 111194.92664455874, 0.000001) {
+		t.Errorf("Expected width 111194.92664455874, got %v", box.Width().Value(common.Meters))
+	}
+	if !common.WithinTolerance(box.Height().Value(common.Meters), 111194.92664455874, 0.000001) {
+		t.Errorf("Expected height 111194.92664455874, got %v", box.Height().Value(common.Meters))
+	}
+	location3, _ := common.NewLocation(-2, 2)
+	location4, _ := common.NewLocation(2, -2)
+
+	box = common.NewBoundingBox(common.Locations{location, location2, location3, location4})
+
+	if !box.IsValid() {
+		t.Errorf("Expected valid bounding box")
+	}
+	if !box.Maximum().IsValid() {
+		t.Errorf("Expected valid maximum for valid bounding box")
+	}
+	if !box.Minimum().IsValid() {
+		t.Errorf("Expected valid minimum for valid bounding box")
+	}
+	if box.Maximum().Latitude() != 2 {
+		t.Errorf("Expected maximum latitude 2, got %v", box.Maximum().Latitude())
+	}
+	if box.Maximum().Longitude() != 2 {
+		t.Errorf("Expected maximum longitude 2, got %v", box.Maximum().Longitude())
+	}
+	if box.Minimum().Latitude() != -2 {
+		t.Errorf("Expected minimum latitude -2, got %v", box.Minimum().Latitude())
+	}
+	if box.Minimum().Longitude() != -2 {
+		t.Errorf("Expected minimum longitude -2, got %v", box.Minimum().Longitude())
+	}
+	if !common.WithinTolerance(box.Width().Value(common.Meters), 444508.6487983116, 0.000001) {
+		t.Errorf("Expected width 222389.85328911748, got %v", box.Width().Value(common.Meters))
+	}
+	if !common.WithinTolerance(box.Height().Value(common.Meters), 444779.70657823497, 0.000001) {
+		t.Errorf("Expected height 222389.85328911748, got %v", box.Height().Value(common.Meters))
+	}
+}

--- a/nextroute/common/distance.go
+++ b/nextroute/common/distance.go
@@ -8,18 +8,18 @@ type DistanceUnit int
 
 // NewDistance returns a new distance.
 func NewDistance(
-	meters float64,
+	value float64,
 	unit DistanceUnit,
 ) Distance {
 	switch unit {
 	case Kilometers:
-		meters *= factorKilometersToMeters
+		value *= factorKilometersToMeters
 	case Miles:
-		meters *= factorMilesToMeters
+		value *= factorMilesToMeters
 	}
 
 	return Distance{
-		meters: meters,
+		meters: value,
 		unit:   unit,
 	}
 }

--- a/nextroute/factory/construction.go
+++ b/nextroute/factory/construction.go
@@ -18,15 +18,38 @@ type ClusterSolutionOptions struct {
 // FilterAreaOptions configure how the [NewGreedySolution] function builds [sdkNextRoute.Solution]. It limits the area
 // one vehicle can cover during construction. This limit is only applied during the construction of the solution.
 type FilterAreaOptions struct {
-	MaximumWidth  float64 `json:"maximum_width" usage:"maximum width of the area in meters" default:"100000" minimum:"0"`
-	MaximumHeight float64 `json:"maximum_height" usage:"maximum height of the area in meters" default:"100000" minimum:"0"`
-	MaximumRadius float64 `json:"maximum_radius" usage:"maximum radius of the area in meters" default:"100000" minimum:"0"`
+	MaximumSide float64 `json:"maximum_side" usage:"maximum side of the square area in meters" default:"100000" minimum:"0"`
 }
 
 // GreedySolutionOptions configure how the [NewGreedySolution] function builds [sdkNextRoute.Solution].
 type GreedySolutionOptions struct {
 	ClusterSolutionOptions ClusterSolutionOptions `json:"cluster_solution_options" usage:"options for the cluster solution"`
 	FilterAreaOptions      FilterAreaOptions      `json:"filter_area_options" usage:"options for the filter area"`
+}
+
+// NewStartSolution returns a start solution. It uses input, factoryOptions and
+// modelFactory to create a model to create a start solution. The start solution
+// is created using the given solveOptions and clusterSolutionOptions. The
+// solveOptions is used to limit the duration and the number of parallel runs at
+// the same time. The clusterSolutionOptions is used to create the clusters to
+// create the start solution, see [NewClusterSolution].
+func NewStartSolution(
+	ctx context.Context,
+	input schema.Input,
+	factoryOptions Options,
+	modelFactory ModelFactory,
+	solveOptions sdkNextRoute.ParallelSolveOptions,
+	clusterSolutionOptions ClusterSolutionOptions,
+) (sdkNextRoute.Solution, error) {
+	connect.Connect(con, &newStartSolution)
+	return newStartSolution(
+		ctx,
+		input,
+		factoryOptions,
+		modelFactory,
+		solveOptions,
+		clusterSolutionOptions,
+	)
 }
 
 // NewGreedySolution returns a greedy solution for the given input.

--- a/nextroute/factory/construction.go
+++ b/nextroute/factory/construction.go
@@ -15,6 +15,8 @@ type ClusterSolutionOptions struct {
 	Speed float64 `json:"speed" usage:"speed of the vehicle in meters per second" default:"10" minimum:"0"`
 }
 
+// FilterAreaOptions configure how the [NewGreedySolution] function builds [sdkNextRoute.Solution]. It limits the area
+// one vehicle can cover during construction. This limit is only applied during the construction of the solution.
 type FilterAreaOptions struct {
 	MaximumWidth  float64 `json:"maximum_width" usage:"maximum width of the area in meters" default:"100000" minimum:"0"`
 	MaximumHeight float64 `json:"maximum_height" usage:"maximum height of the area in meters" default:"100000" minimum:"0"`

--- a/nextroute/factory/construction.go
+++ b/nextroute/factory/construction.go
@@ -1,0 +1,216 @@
+package factory
+
+import (
+	"context"
+
+	"github.com/nextmv-io/sdk/connect"
+	sdkNextRoute "github.com/nextmv-io/sdk/nextroute"
+	"github.com/nextmv-io/sdk/nextroute/common"
+	"github.com/nextmv-io/sdk/nextroute/schema"
+)
+
+// ClusterSolutionOptions configure how the [NewGreedySolution] function builds [sdkNextRoute.Solution].
+type ClusterSolutionOptions struct {
+	Depth int     `json:"depth" usage:"maximum failed tries to add a cluster to a vehicle" default:"10" minimum:"0"`
+	Speed float64 `json:"speed" usage:"speed of the vehicle in meters per second" default:"10" minimum:"0"`
+}
+
+type FilterAreaOptions struct {
+	MaximumWidth  float64 `json:"maximum_width" usage:"maximum width of the area in meters" default:"100000" minimum:"0"`
+	MaximumHeight float64 `json:"maximum_height" usage:"maximum height of the area in meters" default:"100000" minimum:"0"`
+	MaximumRadius float64 `json:"maximum_radius" usage:"maximum radius of the area in meters" default:"100000" minimum:"0"`
+}
+
+// GreedySolutionOptions configure how the [NewGreedySolution] function builds [sdkNextRoute.Solution].
+type GreedySolutionOptions struct {
+	ClusterSolutionOptions ClusterSolutionOptions `json:"cluster_solution_options" usage:"options for the cluster solution"`
+	FilterAreaOptions      FilterAreaOptions      `json:"filter_area_options" usage:"options for the filter area"`
+}
+
+// NewGreedySolution returns a greedy solution for the given input.
+func NewGreedySolution(
+	ctx context.Context,
+	input schema.Input,
+	options Options,
+	greedySolutionOptions GreedySolutionOptions,
+	modelFactory ModelFactory,
+) (sdkNextRoute.Solution, error) {
+	connect.Connect(con, &newGreedySolution)
+	return newGreedySolution(
+		ctx,
+		input,
+		options,
+		greedySolutionOptions,
+		modelFactory,
+	)
+}
+
+// StopCluster represents a group of stops that can be added to a vehicle.
+type StopCluster interface {
+	// Stops returns the stops in the stop cluster.
+	Stops() []schema.Stop
+	// Centroid returns the centroid of the stop cluster.
+	Centroid() schema.Location
+}
+
+// NewStopCluster returns a new stop cluster for the given stops.
+func NewStopCluster(
+	stops []schema.Stop) StopCluster {
+	connect.Connect(con, &newStopCluster)
+	return newStopCluster(stops)
+}
+
+// NewPlanUnitStopClusterGenerator returns a list of stop clusters based
+// upon unplanned plan units.
+func NewPlanUnitStopClusterGenerator() StopClusterGenerator {
+	connect.Connect(con, &newPlanUnitStopClusterGenerator)
+	return newPlanUnitStopClusterGenerator()
+}
+
+// NewSortStopClustersRandom returns StopClusterSorter which sorts the stop
+// clusters randomly. Can be used to randomize the order of the stop clusters
+// assigned to the vehicles as the first cluster.
+func NewSortStopClustersRandom() StopClusterSorter {
+	connect.Connect(con, &newSortStopClustersRandom)
+	return newSortStopClustersRandom()
+}
+
+// NewSortStopClustersOnDistanceFromCentroid sorts the stop clusters based upon
+// the distance from the centroid of the stop cluster to the centroid of all
+// stops. Can be used to select the order of the stop clusters assigned to the
+// vehicles as the first cluster.
+func NewSortStopClustersOnDistanceFromCentroid() StopClusterSorter {
+	connect.Connect(con, &newSortStopClustersOnDistanceFromCentroid)
+	return newSortStopClustersOnDistanceFromCentroid()
+}
+
+// NewStopClusterFilterArea returns a StopClusterFilter that filters out stop
+// clusters that result in an area larger than the dimensions specified.
+// The area is approximated using haversine distance.
+func NewStopClusterFilterArea(
+	maximumWidth common.Distance,
+	maximumHeight common.Distance,
+	maximumRadius common.Distance,
+) StopClusterFilter {
+	connect.Connect(con, &newStopClusterFilterArea)
+	return newStopClusterFilterArea(maximumWidth, maximumHeight, maximumRadius)
+}
+
+// NewAndStopClusterFilter returns a StopClusterFilter that filters out stop
+// clusters that are filtered out by all the given filters.
+func NewAndStopClusterFilter(
+	filter StopClusterFilter,
+	filters ...StopClusterFilter,
+) StopClusterFilter {
+	connect.Connect(con, &newAndStopClusterFilter)
+	return newAndStopClusterFilter(filter, filters...)
+}
+
+// NewOrStopClusterFilter returns a StopClusterFilter that filters out stop
+// clusters that are filtered out by any of the given filters.
+func NewOrStopClusterFilter(
+	filter StopClusterFilter,
+	filters ...StopClusterFilter,
+) StopClusterFilter {
+	connect.Connect(con, &newOrStopClusterFilter)
+	return newOrStopClusterFilter(filter, filters...)
+}
+
+// StopClusterGenerator returns a list of stop clusters for the given input.
+type StopClusterGenerator interface {
+	// Generate returns a list of stop clusters for the given input.
+	// A cluster is a group of stops that can be added to a vehicle. If a stop
+	// is added to a cluster all the stops belonging to the same plan units
+	// must be added to the same cluster.
+	Generate(
+		input schema.Input,
+		options Options,
+		factory ModelFactory,
+	) ([]StopCluster, error)
+}
+
+// StopClusterSorter returns a sorted list of stop clusters for the given input.
+type StopClusterSorter interface {
+	// Sort returns a sorted list of stop clusters for the given input.
+	Sort(
+		input schema.Input,
+		clusters []StopCluster,
+		factory ModelFactory,
+	) ([]StopCluster, error)
+}
+
+// StopClusterFilter returns true if the given stop cluster should be filtered
+// out.
+type StopClusterFilter interface {
+	// Filter returns true if the given stop cluster should be filtered out.
+	Filter(
+		input schema.Input,
+		cluster StopCluster,
+		factory ModelFactory,
+	) (bool, error)
+}
+
+// ModelFactory returns a new model for the given input and options.
+type ModelFactory interface {
+	// NewModel returns a new model for the given input and options.
+	NewModel(schema.Input, Options) (sdkNextRoute.Model, error)
+}
+
+// NewDefaultModelFactory returns a default model factory.
+func NewDefaultModelFactory() ModelFactory {
+	connect.Connect(con, &newDefaultModelFactory)
+	return newDefaultModelFactory()
+}
+
+// NewClusterSolution returns a solution for the given input using the given
+// options. The solution is constructed by first creating a solution for each
+// vehicle and then adding stop groups to the vehicles in a greedy fashion.
+//
+//   - Raises an error if the input has initial stops on any of the vehicles.
+//   - Uses haversine distance independent of the input's distance/duration
+//     matrix. Uses the correct distance matrix in the solution returned.
+//   - Uses the speed of the vehicle if defined, otherwise the speed defined in
+//     the options.
+//   - Ignores stop duration groups in construction but not in the solution
+//     returned.
+//
+// # The initial solution is created as following:
+//
+//	Creates the clusters using the stopClusterGenerator
+//
+//	In random order of the vehicles in the input:
+//
+//	 - Add a first cluster to the empty vehicle defined by the
+//	   initialStopClusterSorter
+//	 - If the vehicle is not solved, the cluster is removed and the next cluster
+//	   will be added
+//	 - If no clusters can be added, the vehicle will not be used
+//	 - If a cluster has been added we continue adding clusters to the vehicle in
+//	   the order defined by additionalStopClusterSorter until no more clusters
+//	   can be added
+//
+//	We repeat until no more vehicles or no more clusters to add to the solution.
+func NewClusterSolution(
+	ctx context.Context,
+	input schema.Input,
+	options Options,
+	stopClusterGenerator StopClusterGenerator,
+	initialStopClusterSorter StopClusterSorter,
+	additionalStopClusterSorter StopClusterSorter,
+	stopClusterFilter StopClusterFilter,
+	stopClusterOptions ClusterSolutionOptions,
+	modelFactory ModelFactory,
+) (sdkNextRoute.Solution, error) {
+	connect.Connect(con, &newClusterSolution)
+	return newClusterSolution(
+		ctx,
+		input,
+		options,
+		stopClusterGenerator,
+		initialStopClusterSorter,
+		additionalStopClusterSorter,
+		stopClusterFilter,
+		stopClusterOptions,
+		modelFactory,
+	)
+}

--- a/nextroute/factory/engine.go
+++ b/nextroute/factory/engine.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"github.com/nextmv-io/sdk/nextroute/common"
 
 	"github.com/nextmv-io/sdk/alns"
 	"github.com/nextmv-io/sdk/connect"
@@ -24,4 +25,54 @@ var (
 		alns.Progressioner,
 		...nextroute.Solution,
 	) runSchema.Output
+
+	newGreedySolution func(
+		context.Context,
+		schema.Input,
+		Options,
+		GreedySolutionOptions,
+		ModelFactory,
+	) (nextroute.Solution, error)
+
+	newStopCluster func(
+		[]schema.Stop,
+	) StopCluster
+
+	newPlanUnitStopClusterGenerator func() StopClusterGenerator
+
+	newSortStopClustersRandom func() StopClusterSorter
+
+	newSortStopClustersOnDistanceFromCentroid func() StopClusterSorter
+
+	newSortStopClustersOnRadar func() StopClusterSorter
+
+	newStopClusterFilterArea func(
+		common.Distance,
+		common.Distance,
+		common.Distance,
+	) StopClusterFilter
+
+	newAndStopClusterFilter func(
+		StopClusterFilter,
+		...StopClusterFilter,
+	) StopClusterFilter
+
+	newOrStopClusterFilter func(
+		StopClusterFilter,
+		...StopClusterFilter,
+	) StopClusterFilter
+
+	newClusterSolution func(
+		context.Context,
+		schema.Input,
+		Options,
+		StopClusterGenerator,
+		StopClusterSorter,
+		StopClusterSorter,
+		StopClusterFilter,
+		ClusterSolutionOptions,
+		ModelFactory,
+	) (nextroute.Solution, error)
+
+	newDefaultModelFactory func() ModelFactory
 )

--- a/nextroute/factory/engine.go
+++ b/nextroute/factory/engine.go
@@ -26,6 +26,15 @@ var (
 		...nextroute.Solution,
 	) runSchema.Output
 
+	newStartSolution func(
+		context.Context,
+		schema.Input,
+		Options,
+		ModelFactory,
+		nextroute.ParallelSolveOptions,
+		ClusterSolutionOptions,
+	) (nextroute.Solution, error)
+
 	newGreedySolution func(
 		context.Context,
 		schema.Input,

--- a/nextroute/factory/engine.go
+++ b/nextroute/factory/engine.go
@@ -2,11 +2,11 @@ package factory
 
 import (
 	"context"
-	"github.com/nextmv-io/sdk/nextroute/common"
 
 	"github.com/nextmv-io/sdk/alns"
 	"github.com/nextmv-io/sdk/connect"
 	"github.com/nextmv-io/sdk/nextroute"
+	"github.com/nextmv-io/sdk/nextroute/common"
 	"github.com/nextmv-io/sdk/nextroute/schema"
 	runSchema "github.com/nextmv-io/sdk/run/schema"
 )
@@ -43,8 +43,6 @@ var (
 	newSortStopClustersRandom func() StopClusterSorter
 
 	newSortStopClustersOnDistanceFromCentroid func() StopClusterSorter
-
-	newSortStopClustersOnRadar func() StopClusterSorter
 
 	newStopClusterFilterArea func(
 		common.Distance,


### PR DESCRIPTION
# Description

Introduces a construction heuristic which can deal with stopgroups.

Can be used as following:

```
solution, err := factory.NewGreedySolution(
		ctx,
		input,
		options.Model,
		sdkNextRouteFactory.GreedySolutionOptions{
			ClusterSolutionOptions: sdkNextRouteFactory.ClusterSolutionOptions{
				Depth: 100,
				Speed: 10,
			},
			FilterAreaOptions: sdkNextRouteFactory.FilterAreaOptions{
				MaximumWidth:  math.MaxFloat64,
				MaximumHeight: math.MaxFloat64,
				MaximumRadius: math.MaxFloat64,
			},
		},
		factory.NewDefaultModelFactory(),
	)
```