### PR TITLE
Returns explicit error for no points case

### DIFF
--- a/route/osrm/client.go
+++ b/route/osrm/client.go
@@ -233,6 +233,10 @@ func (c *client) Table(points []route.Point, opts ...TableOptions) (
 		opt(cfg)
 	}
 
+	if len(points) == 0 {
+		return nil, nil, fmt.Errorf("cannot request distances/durations for empty points")
+	}
+
 	// Remove empty points, if requested.
 	originalLength := len(points)
 	var deflatedIndices []int
@@ -551,6 +555,10 @@ type Step struct {
 // from start to end, second parameter is a list of polylines per leg in the
 // route.
 func (c *client) Polyline(points []route.Point) (string, []string, error) {
+	if len(points) == 0 {
+		return "", []string{}, fmt.Errorf("cannot create polyline for empty points")
+	}
+
 	// Turn points slice into OSRM-friendly semicolon-delimited point pairs
 	// []{{1,2}, {3,4}} => "1,2;3,4"
 	pointsParameter := pointsParameter(points)

--- a/route/osrm/client_test.go
+++ b/route/osrm/client_test.go
@@ -265,3 +265,20 @@ const tableResponseOK = `{
 		[245938.6, 0]
 	]
 }`
+
+func TestEmptyPoints(t *testing.T) {
+	ts := newTestServer(t, osrm.TableEndpoint)
+	defer ts.s.Close()
+
+	c := osrm.DefaultClient(ts.s.URL, true)
+
+	_, _, err := c.Table([]route.Point{})
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	_, _, err = c.Polyline([]route.Point{})
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
# Description

Returns an explicit error instead of a 'malformed URL' error from OSRM for the case where no points were provided.