### PR TITLE
ENG-4080 Change default solver duration

### DIFF
--- a/mip/options.go
+++ b/mip/options.go
@@ -12,7 +12,7 @@ import (
 type SolveOptions struct {
 	// Duration is the maximum duration of the solver. A duration limit of 0 is
 	// treated as infinity.
-	Duration time.Duration `json:"duration" usage:"Maximum duration of the solver." default:"30s"`
+	Duration time.Duration `json:"duration" usage:"Maximum duration of the solver." default:"5s"`
 	// Verbosity of the solver in the console.
 	Verbosity Verbosity `json:"verbosity" usage:"{off, low, medium, high} Verbosity of the solver in the console." default:"off"`
 	// MIP-specific options.

--- a/nextroute/solver_parallel.go
+++ b/nextroute/solver_parallel.go
@@ -10,7 +10,7 @@ import (
 // ParallelSolveOptions are the options for the parallel solver.
 type ParallelSolveOptions struct {
 	Iterations           int           `json:"iterations"  usage:"maximum number of iterations, -1 assumes no limit; iterations are counted after start solutions are generated" default:"-1"`
-	Duration             time.Duration `json:"duration" usage:"maximum duration of the solver" default:"30s"`
+	Duration             time.Duration `json:"duration" usage:"maximum duration of the solver" default:"5s"`
 	ParallelRuns         int           `json:"parallel_runs" usage:"maximum number of parallel runs, -1 results in using all available resources" default:"-1"`
 	StartSolutions       int           `json:"start_solutions" usage:"number of solutions to generate on top of those passed in; one solution generated with sweep algorithm, the rest generated randomly" default:"-1"`
 	RunDeterministically bool          `json:"run_deterministically"  usage:"run the parallel solver deterministically"`

--- a/templates/ortools/main.py
+++ b/templates/ortools/main.py
@@ -35,7 +35,7 @@ def main() -> None:
     )
     parser.add_argument(
         "-duration",
-        default=30,
+        default=5,
         help="Max runtime duration (in seconds). Default is 30.",
         type=int,
     )

--- a/templates/xpress/main.py
+++ b/templates/xpress/main.py
@@ -38,7 +38,7 @@ def main() -> None:
     )
     parser.add_argument(
         "-duration",
-        default=30,
+        default=5,
         help="Max runtime duration (in seconds). Default is 30.",
         type=int,
     )


### PR DESCRIPTION
Change the default durations of templates to be `5s`.