### PR TITLE
Extended cluster constraint and objective to exclude first and last stop

### DIFF
--- a/nextroute/model_cluster.go
+++ b/nextroute/model_cluster.go
@@ -13,10 +13,30 @@ type Cluster interface {
 	ConstraintStopDataUpdater
 	ModelConstraint
 	ModelObjective
+
+	// IncludeFirst returns whether the first of the vehicle is included in the
+	// centroid calculation. The centroid is used to determine the distance
+	// between a new stop and the cluster.
+	IncludeFirst() bool
+	// IncludeLast returns whether the lst stop of the vehicle is included in
+	// the centroid calculation. The centroid is used to determine the distance
+	//between a new stop and the cluster.
+	IncludeLast() bool
+
+	// SetIncludeFirst sets whether the first stop of the vehicle is included in
+	// the centroid calculation. The centroid is used to determine the distance
+	// between a new stop and the cluster.
+	SetIncludeFirst(includeFirst bool)
+	// SetIncludeLast sets whether the last stop of the vehicle is included in
+	// the centroid calculation. The centroid is used to determine the distance
+	//between a new stop and the cluster.
+	SetIncludeLast(includeLast bool)
 }
 
 // NewCluster creates a new cluster component. It needs to be added as a
 // constraint or as an objective to the model to be taken into account.
+// By default, the first and last stop of a vehicle are not included in the
+// centroid calculation.
 func NewCluster() (Cluster, error) {
 	connect.Connect(con, &newCluster)
 	return newCluster()

--- a/nextroute/model_cluster.go
+++ b/nextroute/model_cluster.go
@@ -18,7 +18,7 @@ type Cluster interface {
 	// centroid calculation. The centroid is used to determine the distance
 	// between a new stop and the cluster.
 	IncludeFirst() bool
-	// IncludeLast returns whether the lst stop of the vehicle is included in
+	// IncludeLast returns whether the last stop of the vehicle is included in
 	// the centroid calculation. The centroid is used to determine the distance
 	// between a new stop and the cluster.
 	IncludeLast() bool

--- a/nextroute/model_cluster.go
+++ b/nextroute/model_cluster.go
@@ -20,7 +20,7 @@ type Cluster interface {
 	IncludeFirst() bool
 	// IncludeLast returns whether the lst stop of the vehicle is included in
 	// the centroid calculation. The centroid is used to determine the distance
-	//between a new stop and the cluster.
+	// between a new stop and the cluster.
 	IncludeLast() bool
 
 	// SetIncludeFirst sets whether the first stop of the vehicle is included in
@@ -29,7 +29,7 @@ type Cluster interface {
 	SetIncludeFirst(includeFirst bool)
 	// SetIncludeLast sets whether the last stop of the vehicle is included in
 	// the centroid calculation. The centroid is used to determine the distance
-	//between a new stop and the cluster.
+	// between a new stop and the cluster.
 	SetIncludeLast(includeLast bool)
 }
 

--- a/nextroute/model_cluster.go
+++ b/nextroute/model_cluster.go
@@ -14,7 +14,7 @@ type Cluster interface {
 	ModelConstraint
 	ModelObjective
 
-	// IncludeFirst returns whether the first of the vehicle is included in the
+	// IncludeFirst returns whether the first stop of the vehicle is included in the
 	// centroid calculation. The centroid is used to determine the distance
 	// between a new stop and the cluster.
 	IncludeFirst() bool


### PR DESCRIPTION
Added the option to configure the first and last stop of a vehicle to be considered in calculating the centroid. The default is to exclude them, this is a change of the current implementation and considered a bug fix.