### PR TITLE
feature/eng-4203-custom-measure-for-looking-up-cost-in-a-unique-matrix

### DIFF
--- a/measure/unique.go
+++ b/measure/unique.go
@@ -1,0 +1,37 @@
+package measure
+
+import "encoding/json"
+
+// Unique returns a ByIndex that uses a reference slice to map the indices of a
+// point to the index of the measure.
+// m represents a matrix of unique points.
+// references maps a stop (by index) to an index in m.
+func Unique(m ByIndex, references []int) ByIndex {
+	return &unique{m: m, references: references}
+}
+
+// Struct that implements the ByIndex interface and holds additional data to be
+// able to do so.
+type unique struct {
+	m          ByIndex
+	references []int
+}
+
+// Cost returns the cost between two locations.
+func (u *unique) Cost(from, to int) float64 {
+	return u.m.Cost(u.references[from], u.references[to])
+}
+
+// Triangular returns whether the measure is triangular.
+func (u *unique) Triangular() bool {
+	return IsTriangular(u.m)
+}
+
+// MarshalJSON returns the JSON encoding of the measure.
+func (u *unique) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"measure":    u.m,
+		"type":       "unique",
+		"references": u.references,
+	})
+}

--- a/measure/unique_test.go
+++ b/measure/unique_test.go
@@ -1,0 +1,25 @@
+package measure_test
+
+import (
+	"testing"
+
+	"github.com/nextmv-io/sdk/measure"
+)
+
+func TestUnique(t *testing.T) {
+	uniqueMatrix := measure.Matrix([][]float64{
+		{0, 1, 2},
+		{1, 0, 3},
+		{2, 3, 0},
+	})
+	references := []int{1, 2, 0, 1, 2, 0}
+	m := measure.Unique(uniqueMatrix, references)
+	c := m.Cost(2, 5)
+	if c != 0 {
+		t.Errorf("expected cost to be 0 but was %f", c)
+	}
+	c = m.Cost(0, 4)
+	if c != 3 {
+		t.Errorf("expected cost to be 1 but was %f", c)
+	}
+}

--- a/route/load.go
+++ b/route/load.go
@@ -77,17 +77,18 @@ type ByIndexLoader struct {
 // of onto a map[string]any for type safety and because this will allow
 // recursive measures to be automatically unmarshalled.
 type byIndexJSON struct {
-	ByIndex  *ByIndexLoader          `json:"measure"`
-	Arcs     map[int]map[int]float64 `json:"arcs"`
-	Type     string                  `json:"type"`
-	Measures []ByIndexLoader         `json:"measures"`
-	Costs    []float64               `json:"costs"`
-	Matrix   [][]float64             `json:"matrix"`
-	Constant float64                 `json:"constant"`
-	Scale    float64                 `json:"scale"`
-	Exponent float64                 `json:"exponent"`
-	Lower    float64                 `json:"lower"`
-	Upper    float64                 `json:"upper"`
+	ByIndex    *ByIndexLoader          `json:"measure"`
+	Arcs       map[int]map[int]float64 `json:"arcs"`
+	Type       string                  `json:"type"`
+	Measures   []ByIndexLoader         `json:"measures"`
+	Costs      []float64               `json:"costs"`
+	Matrix     [][]float64             `json:"matrix"`
+	Constant   float64                 `json:"constant"`
+	Scale      float64                 `json:"scale"`
+	Exponent   float64                 `json:"exponent"`
+	Lower      float64                 `json:"lower"`
+	Upper      float64                 `json:"upper"`
+	References []int                   `json:"references"`
 }
 
 // MarshalJSON returns the JSON representation for the underlying Byindex.
@@ -135,6 +136,8 @@ func (l *ByIndexLoader) UnmarshalJSON(b []byte) error {
 		l.byIndex = Sparse(j.ByIndex.To(), j.Arcs)
 	case "truncate":
 		l.byIndex = Truncate(j.ByIndex.To(), j.Lower, j.Upper)
+	case "unique":
+		l.byIndex = Unique(j.ByIndex.To(), j.References)
 	default:
 		return fmt.Errorf(`invalid type "%s"`, j.Type)
 	}

--- a/route/measure.go
+++ b/route/measure.go
@@ -166,6 +166,14 @@ func Truncate(m ByIndex, lower, upper float64) ByIndex {
 	return measure.Truncate(m, lower, upper)
 }
 
+// Unique returns a ByIndex that uses a reference slice to map the indices of a
+// point to the index of the measure.
+// m represents a matrix of unique points.
+// references maps a stop (by index) to an index in m.
+func Unique(m ByIndex, references []int) ByIndex {
+	return measure.Unique(m, references)
+}
+
 // Location measure returns the sum of the cost computed by the passed in
 // measure and the specified cost of the 'to' location. This cost is read from
 // the passed in costs slice.


### PR DESCRIPTION
# Description

This PR adds a new Unique measure to our measures. It takes a unique matrix of costs and a slice of stop references which maps a stop by index (index from the input) to an index in the unique matrix.
The measure does not create the unique matrix etc itself and expects them to be unique. Reason is that this way a unique set of points can be requested from e.g. and OSRM server, and the result can directly be used with this type of measure.

* `unique.go`
* `unique_test.go`