### PR TITLE
Adds missing ortools mip statuses to template

### DIFF
--- a/templates/ortools/main.py
+++ b/templates/ortools/main.py
@@ -15,6 +15,9 @@ STATUS = {
     pywraplp.Solver.INFEASIBLE: "infeasible",
     pywraplp.Solver.OPTIMAL: "optimal",
     pywraplp.Solver.UNBOUNDED: "unbounded",
+    pywraplp.Solver.ABNORMAL: "abnormal",
+    pywraplp.Solver.NOT_SOLVED: "not_solved",
+    pywraplp.Solver.MODEL_INVALID: "model_invalid",
 }
 
 


### PR DESCRIPTION
# Description

Adds the missing OR-Tools MIP statuses to the translation dict. This should help better identifying odd failures.

## Changes

- Adds missing OR-Tools MIP statuses