### PR TITLE
ENG-4256 Adds the provider as an arg

### DIFF
--- a/templates/pyomo/README.md
+++ b/templates/pyomo/README.md
@@ -36,7 +36,7 @@ Follow these steps to run locally.
 1. Run the command below to check that everything works as expected:
 
     ```bash
-    python3 main.py -input input.json -output output.json -duration 30
+    python3 main.py -input input.json -output output.json -duration 30 -provider cbc
     ```
 
 1. A file `output.json` should have been created with the optimal knapsack

--- a/templates/pyomo/README.md
+++ b/templates/pyomo/README.md
@@ -36,7 +36,8 @@ Follow these steps to run locally.
 1. Run the command below to check that everything works as expected:
 
     ```bash
-    python3 main.py -input input.json -output output.json -duration 30 -provider cbc
+    python3 main.py -input input.json -output output.json \
+      -duration 30 -provider cbc
     ```
 
 1. A file `output.json` should have been created with the optimal knapsack

--- a/templates/pyomo/main.py
+++ b/templates/pyomo/main.py
@@ -45,6 +45,11 @@ def main() -> None:
         help="Max runtime duration (in seconds). Default is 30.",
         type=int,
     )
+    parser.add_argument(
+        "-provider",
+        default="cbc",
+        help="Solver provider. Default is cbc.",
+    )
     args = parser.parse_args()
 
     # Read input data, solve the problem and write the solution.
@@ -53,23 +58,22 @@ def main() -> None:
     log(f"  - items: {len(input_data.get('items', []))}")
     log(f"  - capacity: {input_data.get('weight_capacity', 0)}")
     log(f"  - max duration: {args.duration} seconds")
-    solution = solve(input_data, args.duration)
+    solution = solve(input_data, args.duration, args.provider)
     write_output(args.output, solution)
 
 
-def solve(input_data: dict[str, Any], duration: int) -> dict[str, Any]:
+def solve(input_data: dict[str, Any], duration: int, provider: str) -> dict[str, Any]:
     """Solves the given problem and returns the solution."""
 
-    # Creates the model.
-    model = pyo.ConcreteModel()
-
-    # Define the solver provider. Make sure it is installed.
-    provider = "cbc"
+    # Make sure the provider is supported.
     if provider not in SUPPORTED_PROVIDER_DURATIONS:
         raise ValueError(
             f"Unsupported provider: {provider}. The supported providers are: "
             f"{', '.join(SUPPORTED_PROVIDER_DURATIONS.keys())}"
         )
+
+    # Creates the model.
+    model = pyo.ConcreteModel()
 
     # Creates the solver.
     solver = pyo.SolverFactory(provider)


### PR DESCRIPTION
The solver provider for the `pyomo` template is now an arg. It makes sense given that Pyomo, in theory, should allow one to easily swap providers. Also, it is easier for testing.