### PR TITLE
Fixed closest stops on a model stop.

### DIFF
--- a/nextroute/engine.go
+++ b/nextroute/engine.go
@@ -16,10 +16,19 @@ import (
 var (
 	con = connect.NewConnector("sdk", "NextRoute")
 
-	newRandomSolution func(context.Context, Model) (Solution, error)
-	newSweepSolution  func(context.Context, Model) (Solution, error)
-
-	newClusterSolution            func(context.Context, Model) (Solution, error)
+	newRandomSolution func(
+		context.Context,
+		Model,
+	) (Solution, error)
+	newSweepSolution func(
+		context.Context,
+		Model,
+	) (Solution, error)
+	newClusterSolution func(
+		context.Context,
+		Model,
+		int,
+	) (Solution, error)
 	newConstantDurationExpression func(
 		string,
 		time.Duration,

--- a/nextroute/engine.go
+++ b/nextroute/engine.go
@@ -16,8 +16,10 @@ import (
 var (
 	con = connect.NewConnector("sdk", "NextRoute")
 
-	newRandomSolution             func(context.Context, Model) (Solution, error)
-	newSweepSolution              func(context.Context, Model) (Solution, error)
+	newRandomSolution func(context.Context, Model) (Solution, error)
+	newSweepSolution  func(context.Context, Model) (Solution, error)
+
+	newClusterSolution            func(context.Context, Model) (Solution, error)
 	newConstantDurationExpression func(
 		string,
 		time.Duration,
@@ -213,4 +215,8 @@ var (
 		func(Solution) any,
 		...Solution,
 	) schema.Output
+
+	newModelStopsDistanceQueries func(
+		ModelStops,
+	) (ModelStopsDistanceQueries, error)
 )

--- a/nextroute/model_stops_distance_queries.go
+++ b/nextroute/model_stops_distance_queries.go
@@ -1,0 +1,30 @@
+package nextroute
+
+import (
+	"github.com/nextmv-io/sdk/connect"
+	"github.com/nextmv-io/sdk/nextroute/common"
+)
+
+// ModelStopsDistanceQueries is an interface to query distances between stops.
+type ModelStopsDistanceQueries interface {
+	// ModelStops returns the original set of stops that the distance queries
+	// were created from.
+	ModelStops() ModelStops
+	// NearestStops returns the n nearest stops to the given stop, the stop must
+	// be present in the original set of stops.
+	NearestStops(stop ModelStop, n int) (ModelStops, error)
+	// WithinDistanceStops returns the stops within the given distance of the
+	// given stop, the stop must be present in the original set of stops.
+	WithinDistanceStops(
+		stop ModelStop,
+		distance common.Distance,
+	) (ModelStops, error)
+}
+
+// NewModelStopsDistanceQueries returns a new ModelStopsDistanceQueries.
+// The ModelStopsDistanceQueries can be used to query distances between stops.
+// The stops must be a set of stops with valid locations.
+func NewModelStopsDistanceQueries(stops ModelStops) (ModelStopsDistanceQueries, error) {
+	connect.Connect(con, &newModelStopsDistanceQueries)
+	return newModelStopsDistanceQueries(stops)
+}

--- a/nextroute/solution.go
+++ b/nextroute/solution.go
@@ -44,9 +44,10 @@ func NewSweepSolution(
 func NewClusterSolution(
 	ctx context.Context,
 	m Model,
+	maximumClusters int,
 ) (Solution, error) {
 	connect.Connect(con, &newClusterSolution)
-	return newClusterSolution(ctx, m)
+	return newClusterSolution(ctx, m, maximumClusters)
 }
 
 // Solution is a solution to a model.

--- a/nextroute/solution.go
+++ b/nextroute/solution.go
@@ -40,7 +40,9 @@ func NewSweepSolution(
 }
 
 // NewClusterSolution creates a new solution. The solution is created from the
-// given model using a cluster construction heuristic.
+// given model using a cluster construction heuristic. The number of clusters
+// is maximized to the number of empty vehicles in the solution and the
+// maximumClusters parameter.
 func NewClusterSolution(
 	ctx context.Context,
 	m Model,

--- a/nextroute/solution.go
+++ b/nextroute/solution.go
@@ -39,6 +39,16 @@ func NewSweepSolution(
 	return newSweepSolution(ctx, m)
 }
 
+// NewClusterSolution creates a new solution. The solution is created from the
+// given model using a cluster construction heuristic.
+func NewClusterSolution(
+	ctx context.Context,
+	m Model,
+) (Solution, error) {
+	connect.Connect(con, &newClusterSolution)
+	return newClusterSolution(ctx, m)
+}
+
 // Solution is a solution to a model.
 type Solution interface {
 	alns.Solution[Solution]


### PR DESCRIPTION
- Fixes closest stops on a model stop ENG-4306
- Introduces model stop distance queries interface.
- Introduces cluster start solution ENG-4307
- Introduces solve observer for internal use ENG-4308
- Moved observers to it's own package.