### PR TITLE
Fix concurrent map access

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -29,10 +29,6 @@ func NewConnector(slug, prefix string) *Connector {
 
 // Connect connects a method with its implementation.
 func Connect[T any](c *Connector, target *T, suffix ...string) {
-	if _, ok := c.connected[target]; ok {
-		return
-	}
-
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 


### PR DESCRIPTION
# Description

The map access was not protected by the mutex. This PR fixes it.