### PR TITLE
Check for `nil` properties in json validator

### DIFF
--- a/run/validate/json.go
+++ b/run/validate/json.go
@@ -42,10 +42,10 @@ func (j JSONValidator[Input]) Validate(_ context.Context, input any) (retErr err
 		if err != nil {
 			log.Fatal(err)
 		}
+		if s.Properties == nil {
+			s.Properties = map[string]*humaSchema.Schema{}
+		}
 		if _, ok := s.Properties[RecordedOutputKey]; !ok {
-			if s.Properties == nil {
-				s.Properties = map[string]*humaSchema.Schema{}
-			}
 			s.Properties[RecordedOutputKey] = &humaSchema.Schema{}
 		}
 		// serialize s to json

--- a/run/validate/json.go
+++ b/run/validate/json.go
@@ -43,6 +43,9 @@ func (j JSONValidator[Input]) Validate(_ context.Context, input any) (retErr err
 			log.Fatal(err)
 		}
 		if _, ok := s.Properties[RecordedOutputKey]; !ok {
+			if s.Properties == nil {
+				s.Properties = map[string]*humaSchema.Schema{}
+			}
 			s.Properties[RecordedOutputKey] = &humaSchema.Schema{}
 		}
 		// serialize s to json


### PR DESCRIPTION
This prevents a panic in case the json schema properties are `nil`.