### PR TITLE
Add pre-build command to java template

### DIFF
--- a/templates/knapsack-java-ortools/app.yaml
+++ b/templates/knapsack-java-ortools/app.yaml
@@ -3,3 +3,4 @@ type: java
 runtime: ghcr.io/nextmv-io/runtime/java:latest
 files:
   - main.jar
+pre-build: mvn package


### PR DESCRIPTION
Adds a new pre-build directive to the java template to build the jar before pushing it.