### PR TITLE
Rework version output

### DIFF
--- a/run/legacy_encoder.go
+++ b/run/legacy_encoder.go
@@ -84,7 +84,7 @@ func (g *legacyEncoder[Solution, Options]) Encode(
 	}
 	m := Output{
 		Version: schema.Version{
-			Sdk: sdk.VERSION,
+			"sdk": sdk.VERSION,
 		},
 		Options: options,
 	}

--- a/run/schema/schema.go
+++ b/run/schema/schema.go
@@ -2,14 +2,14 @@
 package schema
 
 import (
-	"github.com/nextmv-io/sdk"
+	"runtime/debug"
+	"strings"
+
 	"github.com/nextmv-io/sdk/run/statistics"
 )
 
-// Version of the sdk.
-type Version struct {
-	Sdk string `json:"sdk"`
-}
+// Version info of the output.
+type Version map[string]string
 
 // Output adds Output information by wrapping the solutions.
 type Output struct {
@@ -26,11 +26,45 @@ func NewOutput[Solution any](options any, solutions ...Solution) Output {
 	for i, solution := range solutions {
 		solutionsAny[i] = solution
 	}
+	// collect known dependency versions
+	dependencies := collectKnownDependencies()
 	return Output{
 		Solutions: solutionsAny,
 		Options:   options,
-		Version: Version{
-			Sdk: sdk.VERSION,
-		},
+		Version:   dependencies,
 	}
+}
+
+// knownDependencies is a list of known dependencies that we want to put in the
+// version of the output.
+var knownDependencies = []struct {
+	name string
+	path string
+}{
+	{name: "sdk", path: "github.com/nextmv-io/sdk"},
+	{name: "nextroute", path: "github.com/nextmv-io/nextroute"},
+	{name: "go-mip", path: "github.com/nextmv-io/go-mip"},
+	{name: "go-highs", path: "github.com/nextmv-io/go-highs"},
+	{name: "go-xpress", path: "github.com/nextmv-io/go-xpress"},
+}
+
+func collectKnownDependencies() Version {
+	// We use the debug.ReadBuildInfo to get the version of the dependencies.
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		// If this happens, we're not running in a module context. We cannot
+		// provide the version of the dependencies.
+		return map[string]string{}
+	}
+
+	// Search all dependencies for known ones and collect their versions.
+	deps := map[string]string{}
+	for _, dep := range bi.Deps {
+		for _, knownDep := range knownDependencies {
+			if strings.HasPrefix(dep.Path, knownDep.path) {
+				deps[knownDep.name] = dep.Version
+			}
+		}
+	}
+	return deps
 }

--- a/templates/order-fulfillment-gosdk/main.go
+++ b/templates/order-fulfillment-gosdk/main.go
@@ -485,7 +485,7 @@ func format(
 	o := schema.Output{}
 
 	o.Version = schema.Version{
-		Sdk: sdk.VERSION,
+		"sdk": sdk.VERSION,
 	}
 
 	stats := statistics.NewStatistics()

--- a/version.go
+++ b/version.go
@@ -34,7 +34,7 @@ func getVersion() string {
 
 	for _, dep := range bi.Deps {
 		// We only care about this repo being used as a dependency.
-		if !strings.HasPrefix(dep.Path, "github.com/nextmv-io/sdk") {
+		if !strings.HasPrefix(dep.Path, "github.com/nextmv-io/nextroute") {
 			continue
 		}
 

--- a/version.go
+++ b/version.go
@@ -34,7 +34,7 @@ func getVersion() string {
 
 	for _, dep := range bi.Deps {
 		// We only care about this repo being used as a dependency.
-		if !strings.HasPrefix(dep.Path, "github.com/nextmv-io/nextroute") {
+		if !strings.HasPrefix(dep.Path, "github.com/nextmv-io/sdk") {
 			continue
 		}
 


### PR DESCRIPTION
# Description

As we are moving away from the old plugin based distribution model, we need to adapt how we add the version info to the output (as engines / solvers are now released individually).
