### PR TITLE
nilsbeck/run dag in parallel

### DIFF
--- a/golden/bash.go
+++ b/golden/bash.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
@@ -130,6 +131,12 @@ func BashTestFile(
 				dmp.DiffPrettyText(diffs),
 			)
 		}
+	}
+
+	// Delay the execution of the test to adhere for rate limits.
+	if bashConfig.WaitBefore > 0 {
+		t.Logf("delaying test execution for %v", bashConfig.WaitBefore)
+		<-time.After(time.Duration(bashConfig.WaitBefore) * time.Second)
 	}
 
 	// Test is executed.

--- a/golden/bash.go
+++ b/golden/bash.go
@@ -136,7 +136,7 @@ func BashTestFile(
 	// Delay the execution of the test to adhere for rate limits.
 	if bashConfig.WaitBefore > 0 {
 		t.Logf("delaying test execution for %v", bashConfig.WaitBefore)
-		<-time.After(time.Duration(bashConfig.WaitBefore) * time.Second)
+		<-time.After(bashConfig.WaitBefore)
 	}
 
 	// Test is executed.

--- a/golden/config.go
+++ b/golden/config.go
@@ -79,8 +79,7 @@ type BashConfig struct {
 	// executed.
 	WorkingDir string
 	// WaitBefore adds a delay before running the bash script to handle rate limits.
-	// The delay is in seconds, if the value is set to 0 no delay will be added.
-	WaitBefore int
+	WaitBefore time.Duration
 }
 
 // TransientField represents a field that is transient, this is, dynamic in

--- a/golden/config.go
+++ b/golden/config.go
@@ -78,6 +78,9 @@ type BashConfig struct {
 	// WorkingDir is the directory where the bash script(s) will be
 	// executed.
 	WorkingDir string
+	// WaitBefore adds a delay before running the bash script to handle rate limits.
+	// The delay is in seconds, if the value is set to 0 no delay will be added.
+	WaitBefore int
 }
 
 // TransientField represents a field that is transient, this is, dynamic in

--- a/golden/config.go
+++ b/golden/config.go
@@ -78,7 +78,8 @@ type BashConfig struct {
 	// WorkingDir is the directory where the bash script(s) will be
 	// executed.
 	WorkingDir string
-	// WaitBefore adds a delay before running the bash script to handle rate limits.
+	// WaitBefore adds a delay before running the bash script. This is useful
+	// when throttling is needed, e.g., when dealing with rate limiting.
 	WaitBefore time.Duration
 }
 


### PR DESCRIPTION
# Description

This makes the DAG bash test run in parallel where the DAG allows for it. It also adds a WaitBefore field to the bash config to allow for a waiting time (in seconds) before the bash script is executed. This is useful if you have to wait for rate limits. If the value is set t 0 no delay is applied.