### PR TITLE
Enhanced OSRM Client with Exclude Parameter Support

### DIFF
--- a/measure/osrm/client.go
+++ b/measure/osrm/client.go
@@ -387,6 +387,11 @@ func (c *client) tableRequests( //nolint:gocyclo
 				path += strings.Join(approaches, ";")
 			}
 
+			if len(config.withExclude) > 0 {
+				path += "&exclude="
+				path += strings.Join(config.withExclude, ",")
+			}
+
 			// Set scale factor. This only has an effect on durations.
 			if c.scaleFactor != 1.0 {
 				path += fmt.Sprintf("&scale_factor=%f", c.scaleFactor)
@@ -453,6 +458,7 @@ type tableConfig struct {
 	withDuration     bool
 	parallelRuns     int
 	withApproachCurb bool
+	withExclude      []string
 }
 
 // WithDuration returns a TableOptions function for composing a tableConfig with
@@ -478,6 +484,14 @@ func WithDistance() TableOptions {
 func WithApproachCurb() TableOptions {
 	return func(c *tableConfig) {
 		c.withApproachCurb = true
+	}
+}
+
+// WithExclude returns a TableOptions func for a tableConfig with the exclude
+// parameter set.
+func WithExclude(exclude []string) TableOptions {
+	return func(c *tableConfig) {
+		c.withExclude = exclude
 	}
 }
 

--- a/measure/osrm/client.go
+++ b/measure/osrm/client.go
@@ -362,12 +362,14 @@ func (c *client) tableRequests( //nolint:gocyclo
 				return nil, err
 			}
 
+			// Determine the information to return. If neither distance nor
+			// duration is requested, we return both.
+			isDefault := !config.withDistance && !config.withDuration
 			annotations := []string{}
-			if config.withDuration {
+			if isDefault || config.withDuration {
 				annotations = append(annotations, "duration")
 			}
-
-			if config.withDistance {
+			if isDefault || config.withDistance {
 				annotations = append(annotations, "distance")
 			}
 


### PR DESCRIPTION
# Description
This update introduces the ability to specify exclude parameters in OSRM table requests.

# Changes
- Added support for `exclude` parameter in table requests.
- Adds default of requesting distance AND duration, if nothing is requested explicitly 