### PR TITLE
Enhance golden file testing with rounding functionality

### DIFF
--- a/golden/config.go
+++ b/golden/config.go
@@ -162,6 +162,9 @@ type OutputProcessConfig struct {
 	// VolatileRegexReplacements defines regex replacements to be applied to the
 	// golden file before comparison.
 	VolatileRegexReplacements []VolatileRegexReplacement
+	// RoundingConfig defines how to round fields in the output before
+	// comparison.
+	RoundingConfig []RoundingConfig
 	// VolatileDataFiles are files that contain volatile data and should get
 	// post-processed to be more stable. This is only supported in directory
 	// mode ([BashTest]) of golden bash testing, i.e., this will be ignored in
@@ -171,6 +174,14 @@ type OutputProcessConfig struct {
 	// output file will be stored. If not provided, then the output file is
 	// stored in the current directory.
 	RelativeDestination string
+}
+
+// RoundingConfig defines how to round a field in the output before comparison.
+type RoundingConfig struct {
+	// Key is the JSONPath-like key to the field that should be rounded.
+	Key string
+	// Precision is the number of decimal places to round to.
+	Precision int
 }
 
 // ExecutionConfig defines the configuration for non-SDK golden file tests.

--- a/golden/file.go
+++ b/golden/file.go
@@ -153,6 +153,8 @@ func comparison(
 	inputPath string,
 	config Config,
 ) {
+	var err error
+
 	goldenPath := inputPath + goldenExtension
 	if config.OutputProcessConfig.RelativeDestination != "" {
 		goldenPath = filepath.Join(
@@ -171,6 +173,10 @@ func comparison(
 
 		flattenedOutput = flatten(output)
 		flattenedOutput = replaceTransient(flattenedOutput, config.TransientFields...)
+		flattenedOutput, err = roundFields(flattenedOutput, config.OutputProcessConfig.RoundingConfig...)
+		if err != nil {
+			t.Fatal(err)
+		}
 		nestedOutput, err := nest(flattenedOutput)
 		if err != nil {
 			t.Fatal(err)

--- a/golden/map.go
+++ b/golden/map.go
@@ -95,9 +95,9 @@ func roundFields(
 		if _, isFloat := value.(float64); isFloat {
 			replaced[key] = round(value.(float64), replacement)
 			continue
-		} else {
-			return nil, fmt.Errorf("field %s is not a float", key)
 		}
+
+		return nil, fmt.Errorf("field %s is not a float", key)
 	}
 
 	return replaced, nil

--- a/golden/map_test.go
+++ b/golden/map_test.go
@@ -1,6 +1,7 @@
 package golden
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -460,6 +461,37 @@ func Test_nest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got, _ := nest(tt.args.flattened); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("nest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_round(t *testing.T) {
+	tests := []struct {
+		num       float64
+		want      float64
+		precision int
+	}{
+		{
+			num:       1.23456789,
+			want:      1.235,
+			precision: 3,
+		},
+		{
+			num:       1.234567891234567891234,
+			want:      1.23456789123456789123,
+			precision: 20,
+		},
+		{
+			num:       1.234567891234567891234,
+			want:      1,
+			precision: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("round %d", tt.precision), func(t *testing.T) {
+			if got := round(tt.num, tt.precision); got != tt.want {
+				t.Errorf("round() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description
Introduced rounding configuration for output comparison in golden file testing, allowing more stable control over numerical comparisons. Furthermore, supports wildcard list replacements (same for rounding) from now on.

## Changes
- Added `RoundingConfig` to `OutputProcessConfig` for defining rounding rules before comparison.
- Implemented `roundFields` function to apply rounding based on the new configuration.
- Added rounding logic in the comparison process to handle numerical fields.
- Created `round` function to perform the actual rounding of float64 values.
- Extended unit tests to cover the new rounding functionality.
- Adds support for replacing values for keys defined like `.solutions[].route_length` (mind the `[]`)