### PR TITLE
Fix typos

### DIFF
--- a/measure/haversine.go
+++ b/measure/haversine.go
@@ -27,7 +27,7 @@ func (h haversineByPoint) Cost(p1, p2 Point) float64 {
 	x := 2.0 * radius * math.Atan2(math.Sqrt(a), math.Sqrt(1.0-a))
 
 	// on different architectures x is slightly different. we don't need perfect
-	// precision here, but we do care about reproducability, so we are fine with
+	// precision here, but we do care about reproducibility, so we are fine with
 	// a value that is precise up to millimeters
 	return math.Floor(x*1000.0) / 1000.0
 }

--- a/measure/here/schema.go
+++ b/measure/here/schema.go
@@ -82,7 +82,7 @@ type area struct {
 	West  float64 `json:"west"`
 }
 
-// BoundingBox represents a region using four cooordinates corresponding
+// BoundingBox represents a region using four coordinates corresponding
 // to the furthest points in each of the cardinal directions within that region.
 type BoundingBox struct {
 	North float64

--- a/measure/osrm/client.go
+++ b/measure/osrm/client.go
@@ -158,7 +158,7 @@ func (c *client) get(uri string) (data []byte, err error) {
 
 	if c.useCache {
 		// sha1 is used to shorten the key for faster cache lookup than directly using the lenthy uri as key.
-		// The chance of hash colision is extremely low for sha1.
+		// The chance of hash collision is extremely low for sha1.
 		// The cache is local to the user, which won't become a security threat even when key colides.
 		// G401 (CWE-326): Use of weak cryptographic primitive.
 		/* #nosec */

--- a/run/validate/json.go
+++ b/run/validate/json.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// RecordedOutputKey is the key used to store the pre-recored output in the
+// RecordedOutputKey is the key used to store the pre-recorded output in the
 // input itself. It can be used to handle pre-computed runs.
 const RecordedOutputKey = "__recorded_output"
 


### PR DESCRIPTION
These corrections are only in comments, but I ran [typos-cli](https://github.com/crate-ci/typos) on the repository because of _`Tresholds`_ ("thresholds").

https://github.com/nextmv-io/sdk/blob/9fe2ea13d7097c873057a36dba00372b72606c94/golden/config.go#L115-L132

I figured since that'd be a breaking change I wouldn't include it in this PR, but at least I'd point it out.