### PR TITLE
Allows control over golden file extension

### DIFF
--- a/golden/bash.go
+++ b/golden/bash.go
@@ -65,7 +65,11 @@ func BashTestFile(
 	script string,
 	bashConfig BashConfig,
 ) {
-	goldenFilePath := script + goldenExtension
+	ext := goldenExtension
+	if bashConfig.GoldenExtension != "" {
+		ext = bashConfig.GoldenExtension
+	}
+	goldenFilePath := script + ext
 	// Function run by the test.
 	f := func(t *testing.T) {
 		// Make script path absolute to avoid issues with custom working

--- a/golden/config.go
+++ b/golden/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	CompareConfig CompareConfig
 	// OutputProcessConfig defines how to process the output before comparison.
 	OutputProcessConfig OutputProcessConfig
+	// GoldenExtension is the file extension to use for the golden file. If not
+	// provided, then the default extension (.golden) is used.
+	GoldenExtension string
 	// SkipGoldenComparison skips the comparison against the golden file.
 	SkipGoldenComparison bool
 	// ExitCode defines the expected exit code of the command.
@@ -68,6 +71,9 @@ type BashConfig struct {
 	DisplayStderr bool
 	// OutputProcessConfig defines how to process the output before comparison.
 	OutputProcessConfig OutputProcessConfig
+	// GoldenExtension is the file extension to use for the golden file. If not
+	// provided, then the default extension (.golden) is used.
+	GoldenExtension string
 	// Envs specifies the environment variables to set for execution.
 	Envs [][2]string
 	// PostProcessFunctions defines a list of functions to be executed after the bash

--- a/golden/file.go
+++ b/golden/file.go
@@ -156,7 +156,11 @@ func comparison(
 ) {
 	var err error
 
-	goldenPath := inputPath + goldenExtension
+	ext := goldenExtension
+	if config.GoldenExtension != "" {
+		ext = config.GoldenExtension
+	}
+	goldenPath := inputPath + ext
 	if config.OutputProcessConfig.RelativeDestination != "" {
 		goldenPath = filepath.Join(
 			config.OutputProcessConfig.RelativeDestination,


### PR DESCRIPTION
# Description

This update introduces the ability to specify custom file extensions for golden files.

## Changes

- Added support for custom golden file extensions in `BashConfig` and `Config`.
- Modified golden file path construction to use the custom extension if provided.