### PR TITLE
Fixes int expectation in golden file testing

### DIFF
--- a/golden/file.go
+++ b/golden/file.go
@@ -429,12 +429,17 @@ func valuesAreEqual(config Config, key string, output, expected any) error {
 	}
 
 	if outputInt, IsInt := output.(int); IsInt {
+		expectedFloat, expectedIsFloat := expected.(float64) // JSON unmarshals numbers as float64
 		expectedInt, expectedIsInt := expected.(int)
-		if !expectedIsInt {
+		if !expectedIsInt && !expectedIsFloat {
 			return fmt.Errorf(
-				"key \"%s\": output value %v is int, expected value %v is not",
+				"key \"%s\": output value %v is int, expected value %v is not float64 (JSON unmarshals numbers as float64)",
 				key, outputInt, expected,
 			)
+		}
+
+		if expectedIsFloat {
+			expectedInt = int(expectedFloat)
 		}
 
 		threshold := config.Thresholds.Int


### PR DESCRIPTION
# Description

Improved the comparison logic when expecting int values to account for float64 values, accommodating JSON's number unmarshaling behavior.

## Changes

- Added a check to convert `expected` value from float64 to int if necessary.
- Updated error message to reflect new comparison logic between int and float64 types.