### PR TITLE
Migrates go linter to v2

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -31,7 +31,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.56.2
+          version: v2.1
           working-directory: ${{ matrix.MOD_PATH }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,206 +1,113 @@
-# Options for analysis running. Details: https://golangci-lint.run/usage/configuration/#run-configuration
+version: "2"
 run:
-  timeout: 5m
   go: "1.22"
-
-# Configures linters. Details: https://golangci-lint.run/usage/linters
-linters-settings:
-  # Pick up duplicate code after severe repetition.
-  dupl:
-    threshold: 200
-  # Only allow certain modules to be imported.
-  gomodguard:
-    allowed:
-      modules:
-        - github.com/nextmv-io/sdk
-        - github.com/nextmv-io/sdk/measure/here
-        - github.com/nextmv-io/sdk/measure/osrm
-        - github.com/nextmv-io/sdk/measure/google
-        - github.com/nextmv-io/sdk/measure/routingkit
-        - googlemaps.github.io/maps
-        - github.com/dgraph-io/ristretto
-        - go.uber.org/mock
-        - github.com/google/go-cmp
-        - github.com/hashicorp/golang-lru
-        - github.com/nextmv-io/go-routingkit
-        - github.com/twpayne/go-polyline
-        - googlemaps.github.io/maps
-        - github.com/itzg/go-flagsfiller
-        - github.com/gorilla/schema
-        - github.com/google/uuid
-        - github.com/xeipuuv/gojsonschema
-        - github.com/danielgtaylor/huma
-        - github.com/sergi/go-diff
-  # Functions cannot exceed this cyclomatic complexity.
-  gocyclo:
-    min-complexity: 20
-  # Set correct go version.
-  gosimple:
-    go: "1.22"
-  staticcheck:
-    go: "1.22"
-  stylecheck:
-    go: "1.22"
-  # Check case of struct tags
-  tagliatelle:
-    case:
-      use-field-name: true
-      rules:
-        json: snake
-  # Check line length
-  lll:
-    line-length: 120
-
-# Specifies which linters are enabled. Full list: https://golangci-lint.run/usage/linters/
 linters:
-  # Some linters are just too strict.
-  disable-all: true
+  default: none
   enable:
-    # Checks whether HTTP response body is closed successfully.
     - bodyclose
-    # containedctx is a linter that detects struct contained context.Context field.
     - containedctx
-    # Check the function whether use a non-inherited context.
     - contextcheck
-    # Finds unused code. WARN [runner] The linter 'deadcode' is deprecated
-    # (since v1.49.0) due to: The owner seems to have abandoned the linter.
-    # Replaced by unused.
-    # - deadcode
-    # check declaration order and count of types, constants, variables and functions.
     - decorder
-    # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - dogsled
-    # Tool for code clone detection
     - dupl
-    # Errcheck is a program for checking for unchecked errors in go programs.
-    # These unchecked errors can be critical bugs in some cases.
     - errcheck
-    # Gci controls golang package import order and makes it always deterministic.
-    - gci
-    # Finds repeated strings that could be replaced by a constant.
     - goconst
-    # Provides diagnostics that check for bugs, performance and style issues.
-    # Extensible without recompilation through dynamic rules. Dynamic rules are
-    # written declaratively with AST patterns, filters, report message and
-    # optional suggestion.
     - gocritic
-    # Computes and checks the cyclomatic complexity of functions.
     - gocyclo
-    # Check if comments end in a period.
     - godot
-    # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s
-    # option to check for code simplification.
-    - gofmt
-    # In addition to fixing imports, goimports also formats your code in the
-    # same style as gofmt.
-    - goimports
-    # Allow and block list linter for direct Go module dependencies. This is
-    # different from depguard where there are different block types for example
-    # version constraints and module recommendations.
     - gomodguard
-    # gosec offers another set of security checks in addition to govet
     - gosec
-    # Linter for Go source code that specializes in simplifying a code.
-    - gosimple
-    # Vet examines Go source code and reports suspicious constructs, such as
-    # Printf calls whose arguments do not align with the format string.
     - govet
-    # Enforces consistent import aliases.
     - importas
-    # Detects when assignments to existing variables are not used.
     - ineffassign
-    # Reports long lines.
     - lll
-    # Finds commonly misspelled English words in comments.
     - misspell
-    # Finds naked returns in functions greater than a specified function length.
     - nakedret
-    # Reports deeply nested if statements.
     - nestif
-    # Finds the code that returns nil even if it checks that the error is not nil.
     - nilerr
-    # noctx finds sending http request without context.Context.
     - noctx
-    # Finds slice declarations that could potentially be preallocated.
     - prealloc
-    # Find code that shadows one of Go's predeclared identifiers.
     - predeclared
-    # Fast, configurable, extensible, flexible, and beautiful linter for Go.
-    # Drop-in replacement of golint.
     - revive
-    # Staticcheck is a go vet on steroids, applying a ton of static analysis checks.
     - staticcheck
-    # Finds unused struct fields. WARN [runner] The linter 'structcheck' is
-    # deprecated (since v1.49.0) due to: The owner seems to have abandoned the
-    # linter.  Replaced by unused.
-    # - structcheck
-    # Stylecheck is a replacement for golint.
-    - stylecheck
-    # Checks the struct tags.
     - tagliatelle
-    # Like the front-end of a Go compiler, parses and type-checks Go code.
-    - typecheck
-    # Remove unnecessary type conversions.
     - unconvert
-    # Reports unused function parameters.
     - unparam
-    # Checks Go code for unused constants, variables, functions and types.
     - unused
-    # Finds unused global variables and constants. WARN [runner] The linter
-    # 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have
-    # abandoned the linter.  Replaced by unused.
-    # - varcheck
-    # wastedassign finds wasted assignment statements.
     - wastedassign
-    # Tool for detection of leading and trailing whitespace.
     - whitespace
-
-# List of regexps of issue texts to exclude. Details: https://golangci-lint.run/usage/configuration/#issues-configuration
-issues:
-  # Disable default exclude patterns to surface commonly-ignored linting errors.
-  exclude-use-default: false
-  exclude-rules:
-    # Tag should be 'measure' in both cases ByPoint and ByIndex
-    - path: measure/load\.go
-      linters:
-        - tagliatelle
-      text: measure
-    # Complexity is fine here because of the nature of the code
-    - path: measure/osrm/matrix_test\.go
-      linters:
-        - gosec
-      text: G404
-
-    # Please note that other Go modules have issues that are ignored but are
-    # not listed here. The reason is that linting must be done standing on the
-    # Go module and excluding issues here uses relative paths. That means that
-    # the relative paths from this file start from the root of sdk but for
-    # other modules the relative path start from that module. For that reason,
-    # linting is ignored by using the following syntax on a line: //nolint. If
-    # you look for uses of //nolint you will find the other linting issues
-    # being excluided.
-
-    # Deactivating gocritic because of a gocritic bug that was fixed on October
-    # 6th, but the fix has not yet been released
-    # https://github.com/go-critic/go-critic/pull/1273
-    - path: run/run\.go
-      linters:
-        - gocritic
-      text: newDeref
-    # Deactivate line length in http_runner_config.go because of go tags
-    - path: run/http_runner_config\.go
-      linters:
-        - lll
-
-    # The golden file testing framework is only used internally and doesn't need
-    # to meet the same standards as the rest of the codebase for now.
-    - path: golden/.+\.go
-      linters:
-        - gocyclo
-        - nestif
-        - gosec
-    # The test is only used internally and doesn't need
-    # to meet the same standards as the rest of the codebase for now.
-    - path: run/tests/http/async/main\.go
-      linters:
-        - gosec
+  settings:
+    dupl:
+      threshold: 200
+    gocyclo:
+      min-complexity: 20
+    gomodguard:
+      allowed:
+        modules:
+          - github.com/nextmv-io/sdk
+          - github.com/nextmv-io/sdk/measure/here
+          - github.com/nextmv-io/sdk/measure/osrm
+          - github.com/nextmv-io/sdk/measure/google
+          - github.com/nextmv-io/sdk/measure/routingkit
+          - googlemaps.github.io/maps
+          - github.com/dgraph-io/ristretto
+          - go.uber.org/mock
+          - github.com/google/go-cmp
+          - github.com/hashicorp/golang-lru
+          - github.com/nextmv-io/go-routingkit
+          - github.com/twpayne/go-polyline
+          - googlemaps.github.io/maps
+          - github.com/itzg/go-flagsfiller
+          - github.com/gorilla/schema
+          - github.com/google/uuid
+          - github.com/xeipuuv/gojsonschema
+          - github.com/danielgtaylor/huma
+          - github.com/sergi/go-diff
+    lll:
+      line-length: 120
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+        use-field-name: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - tagliatelle
+        path: measure/load\.go
+        text: measure
+      - linters:
+          - gosec
+        path: measure/osrm/matrix_test\.go
+        text: G404
+      - linters:
+          - gocritic
+        path: run/run\.go
+        text: newDeref
+      - linters:
+          - lll
+        path: run/http_runner_config\.go
+      - linters:
+          - gocyclo
+          - gosec
+          - nestif
+        path: golden/.+\.go
+      - linters:
+          - gosec
+        path: run/tests/http/async/main\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/golden/file.go
+++ b/golden/file.go
@@ -497,7 +497,7 @@ func withinTolerance[T int | float64 | time.Duration](a, b, tolerance T) bool {
 // withinToleranceTime compares two values of type time.Time and returns true
 // if the difference between the two values is within the given tolerance.
 func withinToleranceTime(a, b time.Time, tolerance time.Duration) bool {
-	if a == b {
+	if a.Equal(b) {
 		return true
 	}
 

--- a/measure/google/client.go
+++ b/measure/google/client.go
@@ -382,7 +382,7 @@ func Polylines(
 			for i, leg := range route.Legs {
 				index++
 				for _, steps := range leg.Steps {
-					dec, err := steps.Polyline.Decode()
+					dec, err := steps.Decode()
 					if err != nil {
 						return "", []string{}, err
 					}

--- a/run/flagparser.go
+++ b/run/flagparser.go
@@ -42,10 +42,7 @@ func usage() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	out := fs.Output()
 
-	fmt.Fprint(
-		out,
-		"Nextmv Hybrid Optimization Platform\n",
-	)
-	fmt.Fprint(out, "Usage:\n")
+	_, _ = fmt.Fprint(out, "Nextmv Hybrid Optimization Platform\n")
+	_, _ = fmt.Fprint(out, "Usage:\n")
 	flag.PrintDefaults()
 }

--- a/run/http_runner.go
+++ b/run/http_runner.go
@@ -110,7 +110,7 @@ func NewHTTPRunner[Input, Option, Solution any](
 		),
 	}
 
-	runnerConfig := runner.Runner.RunnerConfig()
+	runnerConfig := runner.RunnerConfig()
 	runner.maxParallel = make(chan struct{}, runnerConfig.Runner.HTTP.MaxParallel)
 
 	// default http server
@@ -173,7 +173,7 @@ func (h *httpRunner[Input, Option, Solution]) setRunnerOption(
 func (h *httpRunner[Input, Option, Solution]) Run(
 	_ context.Context,
 ) error {
-	httpRunnerConfig := h.Runner.RunnerConfig()
+	httpRunnerConfig := h.RunnerConfig()
 	if httpRunnerConfig.Runner.HTTP.Certificate != "" ||
 		httpRunnerConfig.Runner.HTTP.Key != "" {
 		return h.httpServer.ListenAndServeTLS(
@@ -200,7 +200,7 @@ func (h *httpRunner[Input, Option, Solution]) ServeHTTP(
 	// control mechanism to let the request by run async or not.
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go func() {
+	go func() { //nolint:contextcheck
 		defer func() { <-h.maxParallel }()
 		// configure how to turn the request and response into an IOProducer.
 		callbackFunc, producer, err := h.httpRequestHandler(w, req)
@@ -214,7 +214,7 @@ func (h *httpRunner[Input, Option, Solution]) ServeHTTP(
 		requestID := uuid.New().String()
 
 		// get content type from the encoder
-		contentTyper, ok := h.Runner.GetEncoder().(ContentTyper)
+		contentTyper, ok := h.GetEncoder().(ContentTyper)
 		if !ok {
 			handleError(h.httpServer.ErrorLog, async,
 				errors.New("encoder does not implement ContentTyper"), w)

--- a/run/validate/json.go
+++ b/run/validate/json.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -81,7 +82,7 @@ func (j JSONValidator[Input]) Validate(_ context.Context, input any) (retErr err
 		for _, desc := range result.Errors() {
 			sb.WriteString(desc.String() + "\n")
 		}
-		return fmt.Errorf(sb.String())
+		return errors.New(sb.String())
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Migrates the `golangci-lint` settings to the new `v2` version.

## Changes

* Migrates `golangci-lint` settings to the new `v2` version.