### PR TITLE
Allows filtering regex replacements based on golden filename

### DIFF
--- a/golden/file.go
+++ b/golden/file.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -278,6 +279,15 @@ func updateGoldenFile(
 		actualString := string(actualBytes)
 		actualString = regexReplaceAllDefault(actualString)
 		for _, r := range config.OutputProcessConfig.VolatileRegexReplacements {
+			if r.FileRegex != "" {
+				fileName := filepath.Base(goldenPath)
+				if r.FileRegexFullPath {
+					fileName = goldenPath
+				}
+				if !regexp.MustCompile(r.FileRegex).MatchString(fileName) {
+					continue
+				}
+			}
 			actualString = regexReplaceCustom(actualString, r.Replacement, r.Regex)
 		}
 

--- a/golden/file.go
+++ b/golden/file.go
@@ -284,7 +284,12 @@ func updateGoldenFile(
 				if r.FileRegexFullPath {
 					fileName = goldenPath
 				}
-				if !regexp.MustCompile(r.FileRegex).MatchString(fileName) {
+				re, compileErr := regexp.Compile(r.FileRegex)
+				if compileErr != nil {
+					t.Errorf("Invalid regex pattern '%s': %v", r.FileRegex, compileErr)
+					continue
+				}
+				if !re.MatchString(fileName) {
 					continue
 				}
 			}

--- a/golden/regex.go
+++ b/golden/regex.go
@@ -12,6 +12,14 @@ type VolatileRegexReplacement struct {
 	Regex string
 	// Replacement to apply.
 	Replacement string
+	// FileRegex is an optional regex to match the file name. If it is not
+	// empty, the replacement is only applied to files that match the regex.
+	FileRegex string
+	// FileRegexFullPath decides whether the FileRegex should be applied to
+	// the full path of the file or just the file name. If it is true, the
+	// FileRegex is applied to the full path, otherwise it is applied to the
+	// file name only.
+	FileRegexFullPath bool
 }
 
 // regexReplaceAllDefault applies all default regex replacements to the given


### PR DESCRIPTION
# Description

Allows filtering regex replacements based on the path or filename of the golden file. This way it is possible to define regex replacements only for _some_ files instead of applying them to all of them. This is particularly useful, if there are two files that are almost the equal, but one requires a specific replacement.

## Changes

* Allows to filter files that regex replacements get applied to by providing another regex.