### PR TITLE
Rename `Tresholds` to `Thresholds`

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,5 +1,8 @@
 name: go lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   sdk-go-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,5 +1,8 @@
 name: go test
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   sdk-go-build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,5 +1,8 @@
 name: json lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   sdk-json-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,5 +1,8 @@
 name: markdown lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   sdk-markdown-lint:
     runs-on: ubuntu-latest

--- a/golden/config.go
+++ b/golden/config.go
@@ -47,10 +47,10 @@ type Config struct {
 	// fields have a special parsing in the .golden file and they are
 	// stabilized in the comparison.
 	TransientFields []TransientField
-	// Tresholds by data type to be used when comparing actual and expected.
+	// Thresholds by data type to be used when comparing actual and expected.
 	// This configuration is optional, and if not provided then the comparison
 	// between values is hard equality.
-	Thresholds Tresholds
+	Thresholds Thresholds
 	// When DedicatedComparison is defined, then the golden file test will only
 	// compare the keys that are defined in the slice. The keys are defined as
 	// a [JSONPath]-like key. In general, use a dot (.) to recursively enter
@@ -118,10 +118,10 @@ type TransientField struct {
 	Replacement any
 }
 
-// Tresholds by data type to be used when comparing actual and expected. If the
+// Thresholds by data type to be used when comparing actual and expected. If the
 // absolute difference between the two values is less than or equal to the
 // given threshold, then we consider the two values to be equal.
-type Tresholds struct {
+type Thresholds struct {
 	// Float is the threshold to be used when comparing floats.
 	Float float64
 	// Int is the threshold to be used when comparing ints.

--- a/golden/file.go
+++ b/golden/file.go
@@ -349,7 +349,7 @@ func ValidateAgainstSchema(name string, docBytes, schemaBytes []byte) error {
 }
 
 // valuesAreEqual compares two values and returns an error if they are not.
-// Comparison is done based on a treshold value, which is defined in the
+// Comparison is done based on a threshold value, which is defined in the
 // GoldenConfig.
 func valuesAreEqual(config Config, key string, output, expected any) error {
 	if outputString, isString := output.(string); isString {

--- a/golden/file_test.go
+++ b/golden/file_test.go
@@ -206,7 +206,7 @@ func Test_valuesAreEqual(t *testing.T) {
 			name: "int ok within threshold",
 			args: args{
 				config: Config{
-					Thresholds: Tresholds{
+					Thresholds: Thresholds{
 						Int: 4,
 					},
 				},
@@ -240,7 +240,7 @@ func Test_valuesAreEqual(t *testing.T) {
 			name: "float ok within threshold",
 			args: args{
 				config: Config{
-					Thresholds: Tresholds{
+					Thresholds: Thresholds{
 						Float: 0.1,
 					},
 				},
@@ -254,7 +254,7 @@ func Test_valuesAreEqual(t *testing.T) {
 			name: "float ok within custom threshold",
 			args: args{
 				config: Config{
-					Thresholds: Tresholds{
+					Thresholds: Thresholds{
 						Float: 0.1,
 						CustomThresholds: CustomThresholds{
 							Float: map[string]float64{
@@ -333,7 +333,7 @@ func Test_valuesAreEqual(t *testing.T) {
 			name: "time.Time ok with threshold",
 			args: args{
 				config: Config{
-					Thresholds: Tresholds{
+					Thresholds: Thresholds{
 						Time: 16 * time.Hour,
 					},
 				},
@@ -367,7 +367,7 @@ func Test_valuesAreEqual(t *testing.T) {
 			name: "time.Duration ok with threshold",
 			args: args{
 				config: Config{
-					Thresholds: Tresholds{
+					Thresholds: Thresholds{
 						Duration: 500 * time.Millisecond,
 					},
 				},


### PR DESCRIPTION
Following up on https://github.com/nextmv-io/sdk/pull/461#issuecomment-2532226121.

This fixes a typo. Note that the typo is related to the current `type` `Tresholds` -- which would technically be a breaking change. 

Sorry for taking so long! Lost track of this one. 

Let me know if you'd like this PR to include the appropriate version bump.