### PR TITLE
Adds json processing support for golden bash, improves transient wildcards and adds partial match support

### DIFF
--- a/golden/bash.go
+++ b/golden/bash.go
@@ -160,7 +160,6 @@ func processOutput(
 	config OutputProcessConfig,
 	out []byte,
 ) string {
-
 	// Apply JSON specific processing, if requested.
 	var err error
 	if len(config.TransientFields) > 0 || len(config.RoundingConfig) > 0 {

--- a/golden/bash.go
+++ b/golden/bash.go
@@ -172,9 +172,7 @@ func processOutput(
 		// Flatten the map and apply the configured replacements /
 		// modifications.
 		flattenedOutput := flatmap.Do(output)
-		transientFields := config.TransientFields
-		transientFields = append(transientFields, config.TransientFields...)
-		flattenedOutput = replaceTransient(flattenedOutput, transientFields...)
+		flattenedOutput = replaceTransient(flattenedOutput, config.TransientFields...)
 		flattenedOutput, err = roundFields(flattenedOutput, config.RoundingConfig...)
 		if err != nil {
 			t.Fatal(err)

--- a/golden/bash.go
+++ b/golden/bash.go
@@ -107,7 +107,7 @@ func BashTestFile(
 		}
 
 		// Process the output data before comparison.
-		got := processOutput(t, bashConfig.OutputProcessConfig, out)
+		got := processOutput(t, out, goldenFilePath, bashConfig.OutputProcessConfig)
 
 		// Write the output bytes to a .golden file, if the test is being
 		// updated
@@ -157,8 +157,9 @@ func BashTestFile(
 
 func processOutput(
 	t *testing.T,
-	config OutputProcessConfig,
 	out []byte,
+	goldenPath string,
+	config OutputProcessConfig,
 ) string {
 	// Apply JSON specific processing, if requested.
 	var err error
@@ -172,8 +173,11 @@ func processOutput(
 		// Flatten the map and apply the configured replacements /
 		// modifications.
 		flattenedOutput := flatmap.Do(output)
-		flattenedOutput = replaceTransient(flattenedOutput, config.TransientFields...)
-		flattenedOutput, err = roundFields(flattenedOutput, config.RoundingConfig...)
+		flattenedOutput, err = replaceTransient(goldenPath, flattenedOutput, config.TransientFields...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		flattenedOutput, err = roundFields(goldenPath, flattenedOutput, config.RoundingConfig...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/golden/bash.go
+++ b/golden/bash.go
@@ -161,10 +161,33 @@ func processOutput(
 	goldenPath string,
 	config OutputProcessConfig,
 ) string {
-	// Apply JSON specific processing, if requested.
-	var err error
-	if len(config.TransientFields) > 0 || len(config.RoundingConfig) > 0 {
+	// Check whether any JSON modifications are requested.
+	jsonModifications := false
+	for _, field := range config.TransientFields {
+		skip, err := skipFile(goldenPath, field.FileRegex, field.FileRegexFullPath)
+		if err != nil {
+			t.Fatalf("error checking file regex: %v", err)
+		}
+		if !skip {
+			jsonModifications = true
+			break
+		}
+	}
+	for _, rounding := range config.RoundingConfig {
+		skip, err := skipFile(goldenPath, rounding.FileRegex, rounding.FileRegexFullPath)
+		if err != nil {
+			t.Fatalf("error checking file regex: %v", err)
+		}
+		if !skip {
+			jsonModifications = true
+			break
+		}
+	}
+
+	// Apply JSON specific processing (if any were found).
+	if jsonModifications {
 		// Convert the output to a map[string]any for processing.
+		var err error
 		output := map[string]any{}
 		if err = json.Unmarshal(out, &output); err != nil {
 			t.Fatalf("transient fields or rounding config provided, but output is not valid JSON: %v", err)

--- a/golden/bash.go
+++ b/golden/bash.go
@@ -2,6 +2,7 @@ package golden
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nextmv-io/sdk/flatmap"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
@@ -104,15 +106,9 @@ func BashTestFile(
 			t.Fatal(err)
 		}
 
-		got := string(out)
-		if !bashConfig.OutputProcessConfig.KeepVolatileData {
-			// Replace default volatile content with a placeholder
-			got = regexReplaceAllDefault(got)
-		}
-		// Apply custom volatile regex replacements
-		for _, r := range bashConfig.OutputProcessConfig.VolatileRegexReplacements {
-			got = regexReplaceCustom(got, r.Replacement, r.Regex)
-		}
+		// Process the output data before comparison.
+		got := processOutput(t, bashConfig.OutputProcessConfig, out)
+
 		// Write the output bytes to a .golden file, if the test is being
 		// updated
 		if *update || bashConfig.OutputProcessConfig.AlwaysUpdate {
@@ -157,6 +153,58 @@ func BashTestFile(
 			t.Fatalf("error running post-process function: %v", err)
 		}
 	}
+}
+
+func processOutput(
+	t *testing.T,
+	config OutputProcessConfig,
+	out []byte,
+) string {
+
+	// Apply JSON specific processing, if requested.
+	var err error
+	if len(config.TransientFields) > 0 || len(config.RoundingConfig) > 0 {
+		// Convert the output to a map[string]any for processing.
+		output := map[string]any{}
+		if err = json.Unmarshal(out, &output); err != nil {
+			t.Fatal("transient fields or rounding config provided, but output is not valid JSON: ", err)
+		}
+
+		// Flatten the map and apply the configured replacements /
+		// modifications.
+		flattenedOutput := flatmap.Do(output)
+		transientFields := config.TransientFields
+		transientFields = append(transientFields, config.TransientFields...)
+		flattenedOutput = replaceTransient(flattenedOutput, transientFields...)
+		flattenedOutput, err = roundFields(flattenedOutput, config.RoundingConfig...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nestedOutput, err := flatmap.Undo(flattenedOutput)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Marshal the processed output back to JSON.
+		out, err = json.MarshalIndent(nestedOutput, "", "  ")
+		if err != nil {
+			t.Fatal("error marshaling output: ", err)
+		}
+	}
+
+	got := string(out)
+
+	// Apply regex replacements for volatile data.
+	if !config.KeepVolatileData {
+		// Replace default volatile content with a placeholder.
+		got = regexReplaceAllDefault(got)
+	}
+	// Apply custom regex replacements.
+	for _, r := range config.VolatileRegexReplacements {
+		got = regexReplaceCustom(got, r.Replacement, r.Regex)
+	}
+
+	return got
 }
 
 func postProcessVolatileData(

--- a/golden/bash.go
+++ b/golden/bash.go
@@ -166,7 +166,7 @@ func processOutput(
 		// Convert the output to a map[string]any for processing.
 		output := map[string]any{}
 		if err = json.Unmarshal(out, &output); err != nil {
-			t.Fatal("transient fields or rounding config provided, but output is not valid JSON: ", err)
+			t.Fatalf("transient fields or rounding config provided, but output is not valid JSON: %v", err)
 		}
 
 		// Flatten the map and apply the configured replacements /

--- a/golden/config.go
+++ b/golden/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	// in nature, such as the elapsed time, version, start time, etc. Transient
 	// fields have a special parsing in the .golden file and they are
 	// stabilized in the comparison.
+	//
+	// Deprecated: Use OutputProcessConfig.TransientFields instead.
 	TransientFields []TransientField
 	// Tresholds by data type to be used when comparing actual and expected.
 	// This configuration is optional, and if not provided then the comparison
@@ -165,6 +167,11 @@ type OutputProcessConfig struct {
 	// KeepVolatileData indicates whether to keep or replace frequently
 	// changing data.
 	KeepVolatileData bool
+	// TransientFields are keys that hold values which are transient (dynamic)
+	// in nature, such as the elapsed time, version, start time, etc. Transient
+	// fields have a special parsing in the .golden file and they are
+	// stabilized in the comparison.
+	TransientFields []TransientField
 	// VolatileRegexReplacements defines regex replacements to be applied to the
 	// golden file before comparison.
 	VolatileRegexReplacements []VolatileRegexReplacement

--- a/golden/config.go
+++ b/golden/config.go
@@ -110,7 +110,6 @@ type TransientField struct {
 	//
 	// [JSONPath]: https://goessner.net/articles/JsonPath/
 	Key string
-
 	// Replacement is optional, and it is the value that is used to stabilize
 	// the transient field. If a replacement is not provided for the key, the
 	// stabilization happens according to the data type. For example, a
@@ -118,6 +117,14 @@ type TransientField struct {
 	// replaced using [StableDuration], etc. You can use the constants provided
 	// by this package to stabilize the transient fields.
 	Replacement any
+	// FileRegex is an optional regex to match the file name. If it is not
+	// empty, the replacement is only applied to files that match the regex.
+	FileRegex string
+	// FileRegexFullPath decides whether the FileRegex should be applied to
+	// the full path of the file or just the file name. If it is true, the
+	// FileRegex is applied to the full path, otherwise it is applied to the
+	// file name only.
+	FileRegexFullPath bool
 }
 
 // Tresholds by data type to be used when comparing actual and expected. If the
@@ -195,6 +202,14 @@ type RoundingConfig struct {
 	Key string
 	// Precision is the number of decimal places to round to.
 	Precision int
+	// FileRegex is an optional regex to match the file name. If it is not
+	// empty, the rounding is only applied to files that match the regex.
+	FileRegex string
+	// FileRegexFullPath decides whether the FileRegex should be applied to
+	// the full path of the file or just the file name. If it is true, the
+	// FileRegex is applied to the full path, otherwise it is applied to the
+	// file name only.
+	FileRegexFullPath bool
 }
 
 // ExecutionConfig defines the configuration for non-SDK golden file tests.

--- a/golden/file.go
+++ b/golden/file.go
@@ -542,23 +542,31 @@ func validForFileComparison(fileInfo os.FileInfo) bool {
 	return true
 }
 
+// skipFile checks whether a file should be skipped based on the provided
+// fileRegex and fileRegexFullPath. The file is skipped if the goldenPath does
+// not match the fileRegex. If the fileRegex is empty though, the file is not
+// skipped (i.e., it is processed / a catch-all).
 func skipFile(
 	goldenPath string,
 	fileRegex string,
 	fileRegexFullPath bool,
 ) (bool, error) {
+	if !fileRegexFullPath {
+		goldenPath = filepath.Base(goldenPath)
+	}
+
 	if fileRegex != "" {
-		fileName := filepath.Base(goldenPath)
-		if fileRegexFullPath {
-			fileName = goldenPath
-		}
+		// Compile the regex and check if it matches the goldenPath.
+		// If it does not match, we skip the file.
 		re, compileErr := regexp.Compile(fileRegex)
 		if compileErr != nil {
 			return false, fmt.Errorf("error compiling regex %q: %w", fileRegex, compileErr)
 		}
-		if !re.MatchString(fileName) {
+		if !re.MatchString(goldenPath) {
 			return true, nil
 		}
 	}
+
+	// By default, we do not skip files.
 	return false, nil
 }

--- a/golden/file.go
+++ b/golden/file.go
@@ -180,8 +180,11 @@ func comparison(
 		flattenedOutput = flatmap.Do(output)
 		transientFields := config.TransientFields
 		transientFields = append(transientFields, config.OutputProcessConfig.TransientFields...)
-		flattenedOutput = replaceTransient(flattenedOutput, transientFields...)
-		flattenedOutput, err = roundFields(flattenedOutput, config.OutputProcessConfig.RoundingConfig...)
+		flattenedOutput, err = replaceTransient(goldenPath, flattenedOutput, transientFields...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		flattenedOutput, err = roundFields(goldenPath, flattenedOutput, config.OutputProcessConfig.RoundingConfig...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -281,19 +284,12 @@ func updateGoldenFile(
 		actualString := string(actualBytes)
 		actualString = regexReplaceAllDefault(actualString)
 		for _, r := range config.OutputProcessConfig.VolatileRegexReplacements {
-			if r.FileRegex != "" {
-				fileName := filepath.Base(goldenPath)
-				if r.FileRegexFullPath {
-					fileName = goldenPath
-				}
-				re, compileErr := regexp.Compile(r.FileRegex)
-				if compileErr != nil {
-					t.Errorf("Invalid regex pattern '%s': %v", r.FileRegex, compileErr)
-					continue
-				}
-				if !re.MatchString(fileName) {
-					continue
-				}
+			skip, err := skipFile(goldenPath, r.FileRegex, r.FileRegexFullPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if skip {
+				continue
 			}
 			actualString = regexReplaceCustom(actualString, r.Replacement, r.Regex)
 		}
@@ -544,4 +540,25 @@ func validForFileComparison(fileInfo os.FileInfo) bool {
 	}
 
 	return true
+}
+
+func skipFile(
+	goldenPath string,
+	fileRegex string,
+	fileRegexFullPath bool,
+) (bool, error) {
+	if fileRegex != "" {
+		fileName := filepath.Base(goldenPath)
+		if fileRegexFullPath {
+			fileName = goldenPath
+		}
+		re, compileErr := regexp.Compile(fileRegex)
+		if compileErr != nil {
+			return false, fmt.Errorf("error compiling regex %q: %w", fileRegex, compileErr)
+		}
+		if !re.MatchString(fileName) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/golden/file.go
+++ b/golden/file.go
@@ -178,7 +178,9 @@ func comparison(
 		}
 
 		flattenedOutput = flatmap.Do(output)
-		flattenedOutput = replaceTransient(flattenedOutput, config.TransientFields...)
+		transientFields := config.TransientFields
+		transientFields = append(transientFields, config.OutputProcessConfig.TransientFields...)
+		flattenedOutput = replaceTransient(flattenedOutput, transientFields...)
 		flattenedOutput, err = roundFields(flattenedOutput, config.OutputProcessConfig.RoundingConfig...)
 		if err != nil {
 			t.Fatal(err)

--- a/golden/map.go
+++ b/golden/map.go
@@ -100,6 +100,14 @@ func roundFields(
 ) (map[string]any, error) {
 	roundingLookup := map[string]int{}
 	for _, field := range roundedFields {
+		// See whether we should skip this rounding for the given path.
+		skip, err := skipFile(path, field.FileRegex, field.FileRegexFullPath)
+		if err != nil {
+			return nil, fmt.Errorf("error checking file regex: %w", err)
+		}
+		if skip {
+			continue
+		}
 		roundingLookup[field.Key] = field.Precision
 	}
 

--- a/golden/map.go
+++ b/golden/map.go
@@ -4,8 +4,117 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strings"
 	"time"
 )
+
+// filterMatchingJPaths returns paths from candidates that match the wildcard
+// filter pattern. It also returns the candidates that matched the wildcard.
+func filterMatchingJPaths(candidates []string, wildcard string) (result []string, matches []string) {
+	wildParts := parseJPath(wildcard)
+	prefixLen := len(wildParts)
+
+	unique := make(map[string]struct{})
+
+	for _, cand := range candidates {
+		candParts := parseJPath(cand)
+		if isJPathsMatch(wildParts, candParts) {
+			// If candidate matches the wildcard, add it to matches.
+			matches = append(matches, cand)
+
+			// Also, we want to store the unique prefixes.
+			if len(candParts) >= prefixLen {
+				// Collapse the candidate path to its prefix.
+				prefixParts := candParts[:prefixLen]
+				collapsed := collapseJPath(prefixParts)
+				unique[collapsed] = struct{}{}
+			} else {
+				// If candidate is shorter than the wildcard, store it as is.
+				unique[cand] = struct{}{}
+			}
+		}
+	}
+
+	// Extract keys as result
+	for path := range unique {
+		result = append(result, path)
+	}
+	return result, matches
+}
+
+// parseJPath splits a JPath like
+// ".grouped_summaries[0].foo[1].bar.custom.duration" into parts like
+// ["grouped_summaries", "[0]", "foo", "[1]", "bar", "custom", "duration"].
+func parseJPath(jpath string) []string {
+	var parts []string
+	jpath = strings.TrimPrefix(jpath, ".")
+	var sb strings.Builder
+
+	inBracket := false
+	for _, r := range jpath {
+		if r == '.' && !inBracket {
+			if sb.Len() > 0 {
+				parts = append(parts, sb.String())
+				sb.Reset()
+			}
+		} else {
+			if r == '[' {
+				if sb.Len() > 0 {
+					parts = append(parts, sb.String())
+					sb.Reset()
+				}
+				inBracket = true
+			}
+			if r == ']' {
+				inBracket = false
+			}
+			sb.WriteRune(r)
+		}
+	}
+	if sb.Len() > 0 {
+		parts = append(parts, sb.String())
+	}
+	return parts
+}
+
+// collapseJPath combines parts of a JPath into a single string.
+func collapseJPath(parts []string) string {
+	var sb strings.Builder
+	for _, part := range parts {
+		if strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]") {
+			sb.WriteString(part) // No dot prefix for brackets
+		} else {
+			sb.WriteString(".")
+			sb.WriteString(part)
+		}
+	}
+	return sb.String()
+}
+
+// isJPathsMatch checks whether a candidate JPath matches the wildcard
+// path pattern.
+func isJPathsMatch(pattern, candidate []string) bool {
+	pLen := len(pattern)
+	cLen := len(candidate)
+
+	if pLen > cLen {
+		return false
+	}
+
+	for i := 0; i < pLen; i++ {
+		pp := pattern[i]
+		cp := candidate[i]
+
+		if pp == "[]" {
+			if !strings.HasPrefix(cp, "[") || !strings.HasSuffix(cp, "]") {
+				return false
+			}
+		} else if pp != cp {
+			return false
+		}
+	}
+	return true
+}
 
 // replaceTransient replaces all the values in a map whose key is contained in
 // the variadic list of transientFields. The replaced value has a stable value
@@ -15,7 +124,13 @@ func replaceTransient(
 	original map[string]any,
 	transientFields ...TransientField,
 ) (map[string]any, error) {
-	transientLookup := map[string]any{}
+	// Make a copy of the original map to avoid modifying it directly.
+	replaced := make(map[string]any, len(original))
+	for key, value := range original {
+		replaced[key] = value
+	}
+
+	// Apply the replacements one by one.
 	for _, field := range transientFields {
 		// See whether we should skip this replacement for the given path.
 		skip, err := skipFile(path, field.FileRegex, field.FileRegexFullPath)
@@ -25,65 +140,65 @@ func replaceTransient(
 		if skip {
 			continue
 		}
-		transientLookup[field.Key] = field.Replacement
-	}
 
-	replaced := map[string]any{}
-	for key, value := range original {
-		// Check whether the // Keep the original value.
-		replaced[key] = value
-
-		// Check if the field is meant to be replaced. If not, continue.
-		// We also check for wildcard replacements that are meant to replace all
-		// fields in a slice.
-		replacement, isTransient := transientLookup[key]
-		cleanedKey := replaceIndicesInKeys(key)
-		replacementCleaned, isTransientCleaned := transientLookup[cleanedKey]
-		if !isTransient && !isTransientCleaned {
-			// No replacement defined, continue and keep the original value.
-			continue
+		// Find all keys that match the field's key.
+		originalKeys := make([]string, 0, len(replaced))
+		for key := range replaced {
+			originalKeys = append(originalKeys, key)
 		}
-		if isTransientCleaned {
-			replacement = replacementCleaned
-		}
-
-		// Replace the value with the replacement value.
-		if replacement != nil {
-			replaced[key] = replacement
+		replacementKeys, replacedKeys := filterMatchingJPaths(
+			originalKeys,
+			field.Key,
+		)
+		if len(replacedKeys) == 0 {
+			// No keys matched the field's key, so we skip this replacement.
 			continue
 		}
 
-		// No replacement defined, we fall back to default stable values here
-		// (based on type).
+		// Keep the first value found for potential type based fallback
+		// replacement.
+		var firstValue any = replaced[replacedKeys[0]]
 
-		if stringValue, isString := value.(string); isString {
-			if _, err := time.Parse(time.RFC3339, stringValue); err == nil {
-				replaced[key] = StableTime
+		// Remove the matched keys from the original map.
+		for _, key := range replacedKeys {
+			delete(replaced, key)
+		}
+
+		// Insert the replacements.
+		for _, key := range replacementKeys {
+			if field.Replacement != nil {
+				replaced[key] = field.Replacement
 				continue
 			}
 
-			if _, err := time.ParseDuration(stringValue); err == nil {
-				replaced[key] = StableDuration
+			// If the replacement is nil, we fall back to default stable values
+			// (based on the type of the last value found).
+			if stringValue, isString := firstValue.(string); isString {
+				if _, err := time.Parse(time.RFC3339, stringValue); err == nil {
+					replaced[field.Key] = StableTime
+					continue
+				}
+
+				if _, err := time.ParseDuration(stringValue); err == nil {
+					replaced[field.Key] = StableDuration
+					continue
+				}
+
+				replaced[field.Key] = StableText
 				continue
 			}
-
-			replaced[key] = StableText
-			continue
-		}
-
-		if _, isFloat := value.(float64); isFloat {
-			replaced[key] = StableFloat
-			continue
-		}
-
-		if _, IsInt := value.(int); IsInt {
-			replaced[key] = StableInt
-			continue
-		}
-
-		if _, isBool := value.(bool); isBool {
-			replaced[key] = StableBool
-			continue
+			if _, isFloat := firstValue.(float64); isFloat {
+				replaced[field.Key] = StableFloat
+				continue
+			}
+			if _, isInt := firstValue.(int); isInt {
+				replaced[field.Key] = StableInt
+				continue
+			}
+			if _, isBool := firstValue.(bool); isBool {
+				replaced[field.Key] = StableBool
+				continue
+			}
 		}
 	}
 

--- a/golden/map.go
+++ b/golden/map.go
@@ -158,7 +158,7 @@ func replaceTransient(
 
 		// Keep the first value found for potential type based fallback
 		// replacement.
-		var firstValue any = replaced[replacedKeys[0]]
+		firstValue := replaced[replacedKeys[0]]
 
 		// Remove the matched keys from the original map.
 		for _, key := range replacedKeys {

--- a/golden/map.go
+++ b/golden/map.go
@@ -11,17 +11,26 @@ import (
 // the variadic list of transientFields. The replaced value has a stable value
 // according to the data type.
 func replaceTransient(
+	path string,
 	original map[string]any,
 	transientFields ...TransientField,
-) map[string]any {
+) (map[string]any, error) {
 	transientLookup := map[string]any{}
 	for _, field := range transientFields {
+		// See whether we should skip this replacement for the given path.
+		skip, err := skipFile(path, field.FileRegex, field.FileRegexFullPath)
+		if err != nil {
+			return nil, fmt.Errorf("error checking file regex: %w", err)
+		}
+		if skip {
+			continue
+		}
 		transientLookup[field.Key] = field.Replacement
 	}
 
 	replaced := map[string]any{}
 	for key, value := range original {
-		// Keep the original value.
+		// Check whether the // Keep the original value.
 		replaced[key] = value
 
 		// Check if the field is meant to be replaced. If not, continue.
@@ -78,13 +87,14 @@ func replaceTransient(
 		}
 	}
 
-	return replaced
+	return replaced, nil
 }
 
 // roundFields rounds all the values in a map whose key is contained in the
 // variadic list of roundingConfigs. The rounded value has a stable value
 // according to the data type.
 func roundFields(
+	path string,
 	original map[string]any,
 	roundedFields ...RoundingConfig,
 ) (map[string]any, error) {

--- a/golden/map.go
+++ b/golden/map.go
@@ -47,7 +47,7 @@ func filterMatchingJPaths(candidates []string, wildcard string) (result []string
 // ["grouped_summaries", "[0]", "foo", "[1]", "bar", "custom", "duration"].
 func parseJPath(jpath string) []string {
 	var parts []string
-	jpath = strings.TrimPrefix(jpath, ".")
+	jpath = strings.TrimPrefix(jpath, "$.")
 	var sb strings.Builder
 
 	inBracket := false
@@ -80,6 +80,7 @@ func parseJPath(jpath string) []string {
 // collapseJPath combines parts of a JPath into a single string.
 func collapseJPath(parts []string) string {
 	var sb strings.Builder
+	sb.WriteString("$")
 	for _, part := range parts {
 		if strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]") {
 			sb.WriteString(part) // No dot prefix for brackets
@@ -175,28 +176,28 @@ func replaceTransient(
 			// (based on the type of the last value found).
 			if stringValue, isString := firstValue.(string); isString {
 				if _, err := time.Parse(time.RFC3339, stringValue); err == nil {
-					replaced[field.Key] = StableTime
+					replaced[key] = StableTime
 					continue
 				}
 
 				if _, err := time.ParseDuration(stringValue); err == nil {
-					replaced[field.Key] = StableDuration
+					replaced[key] = StableDuration
 					continue
 				}
 
-				replaced[field.Key] = StableText
+				replaced[key] = StableText
 				continue
 			}
 			if _, isFloat := firstValue.(float64); isFloat {
-				replaced[field.Key] = StableFloat
+				replaced[key] = StableFloat
 				continue
 			}
 			if _, isInt := firstValue.(int); isInt {
-				replaced[field.Key] = StableInt
+				replaced[key] = StableInt
 				continue
 			}
 			if _, isBool := firstValue.(bool); isBool {
-				replaced[field.Key] = StableBool
+				replaced[key] = StableBool
 				continue
 			}
 		}

--- a/golden/map_test.go
+++ b/golden/map_test.go
@@ -100,6 +100,61 @@ func Test_replaceTransient(t *testing.T) {
 				".b": true,
 			},
 		},
+		{
+			name: "map with array",
+			args: args{
+				original: map[string]any{
+					".a[0].b": "foo",
+					".a[0].c": 1.2,
+					".a[1].b": "bar",
+					".a[1].c": 3.4,
+				},
+				transientFields: []TransientField{
+					{Key: ".a[].b", Replacement: "text"},
+				},
+			},
+			want: map[string]any{
+				".a[0].b": "text",
+				".a[0].c": 1.2,
+				".a[1].b": "text",
+				".a[1].c": 3.4,
+			},
+		},
+		{
+			name: "map with replaced parent key",
+			args: args{
+				original: map[string]any{
+					".a.b": "foo",
+					".a.c": 1.2,
+				},
+				transientFields: []TransientField{
+					{Key: ".a", Replacement: map[string]int{"foo": 123}},
+				},
+			},
+			want: map[string]any{
+				".a": map[string]int{
+					"foo": 123,
+				},
+			},
+		},
+		{
+			name: "map with multiple replaced parent keys",
+			args: args{
+				original: map[string]any{
+					".a[0].foo.b": 123,
+					".a[0].foo.c": 123,
+					".a[1].foo.b": 456,
+					".a[1].foo.c": 456,
+				},
+				transientFields: []TransientField{
+					{Key: ".a[].foo", Replacement: "replaced"},
+				},
+			},
+			want: map[string]any{
+				".a[0].foo": "replaced",
+				".a[1].foo": "replaced",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/golden/map_test.go
+++ b/golden/map_test.go
@@ -20,119 +20,119 @@ func Test_replaceTransient(t *testing.T) {
 			name: "map with transient int",
 			args: args{
 				original: map[string]any{
-					".a": "foo",
-					".b": 2,
+					"$.a": "foo",
+					"$.b": 2,
 				},
 				transientFields: []TransientField{{Key: ".b"}},
 			},
 			want: map[string]any{
-				".a": "foo",
-				".b": 123,
+				"$.a": "foo",
+				"$.b": 123,
 			},
 		},
 		{
 			name: "map with transient float",
 			args: args{
 				original: map[string]any{
-					".a": "foo",
-					".b": 1.2,
+					"$.a": "foo",
+					"$.b": 1.2,
 				},
 				transientFields: []TransientField{{Key: ".b"}},
 			},
 			want: map[string]any{
-				".a": "foo",
-				".b": 0.123,
+				"$.a": "foo",
+				"$.b": 0.123,
 			},
 		},
 		{
 			name: "map with transient time",
 			args: args{
 				original: map[string]any{
-					".a": "foo",
-					".b": "2023-05-04T19:52:53Z",
+					"$.a": "foo",
+					"$.b": "2023-05-04T19:52:53Z",
 				},
 				transientFields: []TransientField{{Key: ".b"}},
 			},
 			want: map[string]any{
-				".a": "foo",
-				".b": "2023-01-01T00:00:00Z",
+				"$.a": "foo",
+				"$.b": "2023-01-01T00:00:00Z",
 			},
 		},
 		{
 			name: "map with transient time duration",
 			args: args{
 				original: map[string]any{
-					".a": "foo",
-					".b": "666ms",
+					"$.a": "foo",
+					"$.b": "666ms",
 				},
 				transientFields: []TransientField{{Key: ".b"}},
 			},
 			want: map[string]any{
-				".a": "foo",
-				".b": "123ms",
+				"$.a": "foo",
+				"$.b": "123ms",
 			},
 		},
 		{
 			name: "map with transient string",
 			args: args{
 				original: map[string]any{
-					".a": "foo",
-					".b": "bar",
+					"$.a": "foo",
+					"$.b": "bar",
 				},
 				transientFields: []TransientField{{Key: ".b"}},
 			},
 			want: map[string]any{
-				".a": "foo",
-				".b": "text",
+				"$.a": "foo",
+				"$.b": "text",
 			},
 		},
 		{
 			name: "map with transient bool",
 			args: args{
 				original: map[string]any{
-					".a": "foo",
-					".b": true,
+					"$.a": "foo",
+					"$.b": true,
 				},
 				transientFields: []TransientField{{Key: ".b"}},
 			},
 			want: map[string]any{
-				".a": "foo",
-				".b": true,
+				"$.a": "foo",
+				"$.b": true,
 			},
 		},
 		{
 			name: "map with array",
 			args: args{
 				original: map[string]any{
-					".a[0].b": "foo",
-					".a[0].c": 1.2,
-					".a[1].b": "bar",
-					".a[1].c": 3.4,
+					"$.a[0].b": "foo",
+					"$.a[0].c": 1.2,
+					"$.a[1].b": "bar",
+					"$.a[1].c": 3.4,
 				},
 				transientFields: []TransientField{
-					{Key: ".a[].b", Replacement: "text"},
+					{Key: "$.a[].b", Replacement: "text"},
 				},
 			},
 			want: map[string]any{
-				".a[0].b": "text",
-				".a[0].c": 1.2,
-				".a[1].b": "text",
-				".a[1].c": 3.4,
+				"$.a[0].b": "text",
+				"$.a[0].c": 1.2,
+				"$.a[1].b": "text",
+				"$.a[1].c": 3.4,
 			},
 		},
 		{
 			name: "map with replaced parent key",
 			args: args{
 				original: map[string]any{
-					".a.b": "foo",
-					".a.c": 1.2,
+					"$.a.b": "foo",
+					"$.a.c": 1.2,
 				},
 				transientFields: []TransientField{
 					{Key: ".a", Replacement: map[string]int{"foo": 123}},
 				},
 			},
 			want: map[string]any{
-				".a": map[string]int{
+				"$.a": map[string]int{
 					"foo": 123,
 				},
 			},
@@ -141,18 +141,18 @@ func Test_replaceTransient(t *testing.T) {
 			name: "map with multiple replaced parent keys",
 			args: args{
 				original: map[string]any{
-					".a[0].foo.b": 123,
-					".a[0].foo.c": 123,
-					".a[1].foo.b": 456,
-					".a[1].foo.c": 456,
+					"$.a[0].foo.b": 123,
+					"$.a[0].foo.c": 123,
+					"$.a[1].foo.b": 456,
+					"$.a[1].foo.c": 456,
 				},
 				transientFields: []TransientField{
 					{Key: ".a[].foo", Replacement: "replaced"},
 				},
 			},
 			want: map[string]any{
-				".a[0].foo": "replaced",
-				".a[1].foo": "replaced",
+				"$.a[0].foo": "replaced",
+				"$.a[1].foo": "replaced",
 			},
 		},
 	}

--- a/golden/map_test.go
+++ b/golden/map_test.go
@@ -103,7 +103,12 @@ func Test_replaceTransient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := replaceTransient(tt.args.original, tt.args.transientFields...); !reflect.DeepEqual(got, tt.want) {
+			got, err := replaceTransient("test/path/to-file.golden", tt.args.original, tt.args.transientFields...)
+			if err != nil {
+				t.Errorf("replaceTransient() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("replaceTransient() = %v, want %v", got, tt.want)
 			}
 		})

--- a/golden/regex.go
+++ b/golden/regex.go
@@ -25,23 +25,11 @@ type VolatileRegexReplacement struct {
 // regexReplaceAllDefault applies all default regex replacements to the given
 // text.
 func regexReplaceAllDefault(text string) string {
-	text = regexReplaceEndpoints(text)
 	text = regexReplaceGoSemverLike(text, StableVersion)
 	text = regexReplaceGUID(text, "00000000-0000-0000-0000-000000000000")
 	text = regexReplaceElapsed(text, StableDuration)
 	text = regexReplaceElapsedSeconds(text, StableFloat)
 	text = regexReplaceStart(text, StableTime)
-	return text
-}
-
-// regexReplaceEndpoints replaces all endpoints with the default endpoint.
-func regexReplaceEndpoints(text string) string {
-	text = regexp.
-		MustCompile(`us1.api.staging.nxmv.xyz`).
-		ReplaceAllString(text, "api.cloud.nextmv.io")
-	text = regexp.
-		MustCompile(`us1.api.development.nxmv.xyz`).
-		ReplaceAllString(text, "api.cloud.nextmv.io")
 	return text
 }
 

--- a/run/tests/simple/main_test.go
+++ b/run/tests/simple/main_test.go
@@ -24,11 +24,13 @@ func TestGolden(t *testing.T) {
 			Args: []string{
 				"-duration=1s",
 			},
-			TransientFields: []golden.TransientField{
-				{Key: ".version.sdk", Replacement: golden.StableVersion},
-				{Key: ".solutions[0].statistics.time.elapsed", Replacement: golden.StableDuration},
-				{Key: ".solutions[0].statistics.time.elapsed_seconds", Replacement: golden.StableFloat},
-				{Key: ".solutions[0].statistics.time.start", Replacement: golden.StableTime},
+			OutputProcessConfig: golden.OutputProcessConfig{
+				TransientFields: []golden.TransientField{
+					{Key: ".version.sdk", Replacement: golden.StableVersion},
+					{Key: ".solutions[0].statistics.time.elapsed", Replacement: golden.StableDuration},
+					{Key: ".solutions[0].statistics.time.elapsed_seconds", Replacement: golden.StableFloat},
+					{Key: ".solutions[0].statistics.time.start", Replacement: golden.StableTime},
+				},
 			},
 		},
 	)


### PR DESCRIPTION
# Description

Allow certain replacements that were reserved for golden file testing for JSON to also be applied for bash based tests. Furthermore, largely reworks the transient replacement feature.

## Changes

- Allows `TransientFields` and `RoundingConfig` to be used for bash golden file testing too.
- Reworks transient replacement feature.
  - Fixed some wildcard handling.
  - Allowing partial matches.