### PR TITLE
Logs DAG as mermaid diagram for improved transparency

### DIFF
--- a/golden/dag.go
+++ b/golden/dag.go
@@ -45,7 +45,11 @@ func DagTest(t *testing.T, cases []DagTestCase) {
 	}
 
 	// Print the DAG as a Mermaid diagram for visualization.
-	t.Logf("DAG diagram (mermaid):\n%s", dagToMermaid(cases))
+	mermaid, err := dagToMermaid(cases)
+	if err != nil {
+		t.Fatal("error converting DAG to Mermaid format: ", err)
+	}
+	t.Logf("DAG diagram (mermaid):\n%s", mermaid)
 
 	open := cases
 	done := make(map[string]bool)
@@ -134,30 +138,56 @@ func validate(cases []DagTestCase) error {
 	return nil
 }
 
+type mermaidNode struct {
+	ID    string
+	Name  string
+	Needs []string
+}
+
 // dagToMermaid converts a set of DAG test cases to a Mermaid diagram format.
 // This is useful for visualizing the dependencies between test cases.
-func dagToMermaid(cases []DagTestCase) string {
+func dagToMermaid(cases []DagTestCase) (string, error) {
+	// Convert each test case to a Mermaid node.
+	nodesByName := make(map[string]mermaidNode)
+	ct := 0
+	for _, c := range cases {
+		nodesByName[c.Name] = mermaidNode{
+			ID:   fmt.Sprintf("node%d", ct),
+			Name: c.Name,
+		}
+		ct++
+	}
+	for _, c := range cases {
+		n, ok := nodesByName[c.Name]
+		if !ok {
+			return "", fmt.Errorf("case %s not found in nodes", c.Name)
+		}
+		n.Needs = make([]string, 0, len(c.Needs))
+		for _, need := range c.Needs {
+			needNode, ok := nodesByName[need]
+			if !ok {
+				return "", fmt.Errorf("dependency %s not found for case %s", need, c.Name)
+			}
+			n.Needs = append(n.Needs, needNode.ID)
+		}
+		nodesByName[c.Name] = n
+	}
+
+	// Init.
 	sb := &strings.Builder{}
 	sb.WriteString("graph TD\n")
 
-	// Collect all test case names and all referenced dependencies.
-	names := make(map[string]bool)
-	referenced := make(map[string]bool)
-	for _, c := range cases {
-		names[c.Name] = true
-		// Add dependency relationships.
-		for _, need := range c.Needs {
-			referenced[need] = true
-			fmt.Fprintf(sb, "  \"%s\" --> \"%s\"\n", need, c.Name)
+	// Add nodes themselves.
+	for _, n := range nodesByName {
+		fmt.Fprintf(sb, "  %s[%s]\n", n.ID, n.Name)
+	}
+
+	// Add dependency relationships.
+	for _, n := range nodesByName {
+		for _, needID := range n.Needs {
+			fmt.Fprintf(sb, "  %s --> %s\n", needID, n.ID)
 		}
 	}
 
-	// Add isolated nodes (not referenced and have no dependencies).
-	for _, c := range cases {
-		if len(c.Needs) == 0 && !referenced[c.Name] {
-			fmt.Fprintf(sb, "  \"%s\"\n", c.Name)
-		}
-	}
-
-	return sb.String()
+	return sb.String(), nil
 }

--- a/golden/dag.go
+++ b/golden/dag.go
@@ -45,7 +45,7 @@ func DagTest(t *testing.T, cases []DagTestCase) {
 	}
 
 	// Print the DAG as a Mermaid diagram for visualization.
-	t.Logf("DAG diagram:\n%s", dagToMermaid(cases))
+	t.Logf("DAG diagram (mermaid):\n%s", dagToMermaid(cases))
 
 	open := cases
 	done := make(map[string]bool)
@@ -138,7 +138,7 @@ func validate(cases []DagTestCase) error {
 // This is useful for visualizing the dependencies between test cases.
 func dagToMermaid(cases []DagTestCase) string {
 	sb := &strings.Builder{}
-	sb.WriteString("graph TD (mermaid)\n")
+	sb.WriteString("graph TD\n")
 
 	// Collect all test case names and all referenced dependencies.
 	names := make(map[string]bool)

--- a/golden/dag.go
+++ b/golden/dag.go
@@ -148,14 +148,14 @@ func dagToMermaid(cases []DagTestCase) string {
 		// Add dependency relationships.
 		for _, need := range c.Needs {
 			referenced[need] = true
-			fmt.Fprintf(sb, "  %s --> %s\n", need, c.Name)
+			fmt.Fprintf(sb, "  \"%s\" --> \"%s\"\n", need, c.Name)
 		}
 	}
 
 	// Add isolated nodes (not referenced and have no dependencies).
 	for _, c := range cases {
 		if len(c.Needs) == 0 && !referenced[c.Name] {
-			fmt.Fprintf(sb, "  %s\n", c.Name)
+			fmt.Fprintf(sb, "  \"%s\"\n", c.Name)
 		}
 	}
 

--- a/golden/dag.go
+++ b/golden/dag.go
@@ -142,7 +142,7 @@ func dagToMermaid(cases []DagTestCase) string {
 	sb.WriteString("graph TD\n")
 	for _, c := range cases {
 		for _, need := range c.Needs {
-			sb.WriteString(fmt.Sprintf("  %s --> %s\n", need, c.Name))
+			fmt.Fprintf(sb, "  %s --> %s\n", need, c.Name)
 		}
 	}
 	return sb.String()

--- a/golden/dag.go
+++ b/golden/dag.go
@@ -139,7 +139,7 @@ func validate(cases []DagTestCase) error {
 func dagToMermaid(cases []DagTestCase) string {
 	// Convert the DAG to a Mermaid diagram format.
 	sb := &strings.Builder{}
-	sb.WriteString("graph TD\n")
+	sb.WriteString("graph TD (mermaid)\n")
 	for _, c := range cases {
 		for _, need := range c.Needs {
 			fmt.Fprintf(sb, "  %s --> %s\n", need, c.Name)

--- a/golden/dag.go
+++ b/golden/dag.go
@@ -2,6 +2,7 @@ package golden
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -42,6 +43,9 @@ func DagTest(t *testing.T, cases []DagTestCase) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Print the DAG as a Mermaid diagram for visualization.
+	t.Logf("DAG diagram:\n%s", dagToMermaid(cases))
 
 	open := cases
 	done := make(map[string]bool)
@@ -128,4 +132,18 @@ func validate(cases []DagTestCase) error {
 	}
 
 	return nil
+}
+
+// dagToMermaid converts a set of DAG test cases to a Mermaid diagram format.
+// This is useful for visualizing the dependencies between test cases.
+func dagToMermaid(cases []DagTestCase) string {
+	// Convert the DAG to a Mermaid diagram format.
+	sb := &strings.Builder{}
+	sb.WriteString("graph TD\n")
+	for _, c := range cases {
+		for _, need := range c.Needs {
+			sb.WriteString(fmt.Sprintf("  %s --> %s\n", need, c.Name))
+		}
+	}
+	return sb.String()
 }

--- a/golden/dag.go
+++ b/golden/dag.go
@@ -137,13 +137,27 @@ func validate(cases []DagTestCase) error {
 // dagToMermaid converts a set of DAG test cases to a Mermaid diagram format.
 // This is useful for visualizing the dependencies between test cases.
 func dagToMermaid(cases []DagTestCase) string {
-	// Convert the DAG to a Mermaid diagram format.
 	sb := &strings.Builder{}
 	sb.WriteString("graph TD (mermaid)\n")
+
+	// Collect all test case names and all referenced dependencies.
+	names := make(map[string]bool)
+	referenced := make(map[string]bool)
 	for _, c := range cases {
+		names[c.Name] = true
+		// Add dependency relationships.
 		for _, need := range c.Needs {
+			referenced[need] = true
 			fmt.Fprintf(sb, "  %s --> %s\n", need, c.Name)
 		}
 	}
+
+	// Add isolated nodes (not referenced and have no dependencies).
+	for _, c := range cases {
+		if len(c.Needs) == 0 && !referenced[c.Name] {
+			fmt.Fprintf(sb, "  %s\n", c.Name)
+		}
+	}
+
 	return sb.String()
 }

--- a/golden/dag_test.go
+++ b/golden/dag_test.go
@@ -1,0 +1,41 @@
+// Package testing holds tools for testing documentation code.
+package golden
+
+import (
+	"testing"
+)
+
+func Test_dagToMermaid(t *testing.T) {
+	tests := []struct {
+		dagCases []DagTestCase
+		name     string
+	}{
+		{
+			dagCases: []DagTestCase{
+				{
+					Name:  "Case 1",
+					Needs: []string{},
+				},
+				{
+					Name:  "Case 2",
+					Needs: []string{"Case 1"},
+				},
+				{
+					Name:  "Case 3",
+					Needs: []string{"Case 1", "Case 2"},
+				},
+			},
+			name: "valid DAG",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mermaid, err := dagToMermaid(tt.dagCases)
+			if err != nil {
+				t.Errorf("dagToMermaid() error = %v", err)
+				return
+			}
+			t.Logf("DAG diagram (mermaid):\n%s", mermaid)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Logs the DAG of a DAG-Test as a mermaid diagram for improved transparency. This allows the user to better understand in which order test cases will get executed.

## Changes

- Logs DAG as mermaid diagram.

## Preview

Preview of a DAG visualized from mermaid representation:

<img width="3509" height="2342" alt="image" src="https://github.com/user-attachments/assets/9ef1fe7c-df49-4aed-9bcd-51ba1581dc9f" />
