### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -25,15 +25,15 @@ jobs:
           ]
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.1
           working-directory: ${{ matrix.MOD_PATH }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       # Checks out the changes.
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # Sets up Go with the version set before.
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: |

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 18.8
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: DavidAnson/markdownlint-cli2-action@v7
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,6 +13,6 @@ jobs:
       - name: git clone
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: DavidAnson/markdownlint-cli2-action@v7
+      - uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b  # v23.1.0
         with:
           globs: "**/*.md"


### PR DESCRIPTION
# Description

Pins all workflow actions to their latest version via shas for improved security (avoiding supply chain attacks).

## Changes

- `actions/checkout`: `v4` → `v6.0.2` (`de0fac2e4500...`)
- `actions/setup-go`: `v5` → `v6.4.0` (`4a3601121dd0...`)
- `golangci/golangci-lint-action`: `v8` → `v9.2.0` (`1e7e51e771db...`)
- `actions/setup-node`: `v3` → `v6.4.0` (`48b55a011bda...`)
